### PR TITLE
[CIAS30-3415] adjust endpoint to clone to accept emails instead of user_ids

### DIFF
--- a/app/controllers/v1/interventions_controller.rb
+++ b/app/controllers/v1/interventions_controller.rb
@@ -96,7 +96,7 @@ class V1::InterventionsController < V1Controller
 
   def to_permit
     @to_permit ||= {
-      intervention: [{ user_ids: [] }],
+      intervention: [{ emails: [] }],
       session: [],
       question: [],
       sms_plan: []

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -4,9 +4,9 @@ module Clone
   include MetaOperations
 
   def clone(params: {}, clean_formulas: true, position: nil, hidden: false)
-    if params[:user_ids].present?
+    if params[:emails].present?
       interventions = []
-      user_ids = User.where(id: params[:user_ids]).limit_to_roles(%w[e_intervention_admin researcher]).pluck(:id)
+      user_ids = User.where(email: params[:emails]).limit_to_roles(%w[e_intervention_admin researcher]).pluck(:id)
       user_ids.each do |id|
         interventions.push(
           "Clone::#{de_constantize_modulize_name.classify}".

--- a/spec/jobs/clone_jobs/intervention_spec.rb
+++ b/spec/jobs/clone_jobs/intervention_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe CloneJobs::Intervention, type: :job do
     let(:researcher1) { create(:user, :confirmed, :researcher) }
     let(:researcher2) { create(:user, :confirmed, :researcher) }
     let!(:clone_params) do
-      { user_ids: [
-        researcher1.id,
-        researcher2.id
+      { emails: [
+        researcher1.email,
+        researcher2.email
       ] }
     end
 

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Intervention, type: :model do
 
     context 'when researcher want to assign the intervention to other resarcher' do
       let(:other_user) { create(:user, :confirmed, :researcher) }
-      let(:params) { { user_ids: [other_user.id] } }
+      let(:params) { { emails: [other_user.email] } }
 
       it 'create a new intervention with correct user_id' do
         cloned_intervention = intervention.clone(params: params)

--- a/spec/requests/v1/interventions/clone_spec.rb
+++ b/spec/requests/v1/interventions/clone_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe 'POST /v1/interventions/:id/clone', type: :request do
         intervention.attributes.except('id', 'created_at', 'updated_at')
       end
 
-      let(:intervention_cloned) do
-        json_response['data']['attributes'].except('id', 'created_at', 'updated_at', 'sessions')
-      end
-
       it { expect(response).to have_http_status(:ok) }
     end
   end


### PR DESCRIPTION
## Related tasks
- [CIAS-3415](https://htdevelopers.atlassian.net/browse/CIAS30-3415)

## What's new?
- accept `emails` instead of `user_ids`
- remove unused `let` 
