### PR TITLE
replaced deprecating command - set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     name: Prepare environment & split tests
     runs-on: ubuntu-20.04
     outputs:
-      test-chunks: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
-      test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
+      test-chunks: ${{ steps.set-test-chunks.outputs.test-chunks }}
+      test-chunk-ids: ${{ steps.set-test-chunk-ids.outputs.test-chunk-ids }}
 
     steps:
       - name: Checkout code
@@ -43,7 +43,7 @@ jobs:
         name: Set Chunk IDs
         run: echo "test-chunk-ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
         env:
-          CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
+          CHUNKS: ${{ steps.set-test-chunks.outputs.test-chunks }}
 
   test:
     name: Test batch no. ${{ matrix.chunk }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        chunk: ${{ fromJson(needs.setup_environment.outputs['test-chunk-ids']) }}
+        chunk: ${{ fromJson(needs.setup_environment.outputs.test-chunk-ids) }}
     services:
       database:
         image: postgres:13.0-alpine
@@ -100,7 +100,7 @@ jobs:
           bundle exec rails db:create db:schema:load --trace
       - name: Run test batch
         env:
-          CHUNKS: ${{ needs.setup_environment.outputs['test-chunks'] }}
+          CHUNKS: ${{ needs.setup_environment.outputs.test-chunks }}
           #sed is needed because rspec prepends './' to file paths which contain '"' character and this jq command returns them in such format
         run: bundle exec rspec $(echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | sed 's/\"//g')
       - name: Analyze with bundler audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
       - id: set-test-chunks
         name: Set Chunks
         #the test_setup.sh script returns a list of all spec files and passes that to jq, which groups them up in batches (amount of batches specified by GitHub secret TEST_BATCH_COUNT)
-        run: echo "::set-output name=test-chunks::$(./.github/workflows/test_setup.sh ./spec | jq -cM '[to_entries | group_by(.key % ${{ secrets.TEST_BATCH_COUNT }}) | .[] | map(.value)]')"
+        run: echo "test-chunks=$(./.github/workflows/test_setup.sh ./spec | jq -cM '[to_entries | group_by(.key % ${{ secrets.TEST_BATCH_COUNT }}) | .[] | map(.value)]')" >> $GITHUB_OUTPUT
 
       - id: set-test-chunk-ids
         name: Set Chunk IDs
-        run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"
+        run: echo "test-chunk-ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
         env:
           CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
 


### PR DESCRIPTION
## What's new?
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
