### PR TITLE
[CIAS30-3422][CIAS30-3420] too many notifications after leaving the channel + Editing is not stopped on channel unsubscribe

### DIFF
--- a/app/channels/intervention_channel.rb
+++ b/app/channels/intervention_channel.rb
@@ -13,7 +13,8 @@ class InterventionChannel < ApplicationCable::Channel
 
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
-    purge_editor_and_create_notifications!(Intervention.find(params[:id])) if intervention.current_editor_id == current_user.id
+    intervention = Intervention.find(params[:id])
+    purge_editor_and_create_notifications!(intervention) if intervention.current_editor_id == current_user.id
     stop_all_streams
   end
 

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -184,7 +184,7 @@ class Intervention < ApplicationRecord
   def ability_to_update_for?(user)
     return true unless collaborators.any?
 
-    current_editor_id.blank? || current_editor_id == user.id
+    current_editor_id == user.id
   end
 
   def remove_short_links

--- a/spec/channels/intervention_channel_spec.rb
+++ b/spec/channels/intervention_channel_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe InterventionChannel, type: :channel do
         expect { perform :on_editing_started, interventionId: intervention.id }
           .to have_broadcasted_to("intervention_channel_#{intervention.id}")
                 .with({
-                        data: { editor_id: current_user.id, email: current_user.email, first_name: current_user.first_name,
-                                last_name: current_user.last_name }, topic: 'editing_started', status: 200
+                        data: { current_editor: { id: current_user.id, email: current_user.email, first_name: current_user.first_name,
+                                                  last_name: current_user.last_name } }, topic: 'editing_started', status: 200
                       })
       end
 
@@ -104,8 +104,8 @@ RSpec.describe InterventionChannel, type: :channel do
       it 'brodcast message' do
         expect { perform :on_force_editing_started, interventionId: intervention.id }
           .to have_broadcasted_to("intervention_channel_#{intervention.id}")
-                .with({ data: { editor_id: current_user.id, email: current_user.email, first_name: current_user.first_name,
-                                last_name: current_user.last_name, previous_editor_id: researcher.id }, topic: 'force_editing_started', status: 200 })
+                .with({ data: { current_editor: { id: current_user.id, email: current_user.email, first_name: current_user.first_name,
+                                                  last_name: current_user.last_name }, topic: 'force_editing_started', status: 200 } })
       end
 
       context 'when current user isn\'t the owner' do

--- a/spec/channels/intervention_channel_spec.rb
+++ b/spec/channels/intervention_channel_spec.rb
@@ -104,8 +104,10 @@ RSpec.describe InterventionChannel, type: :channel do
       it 'brodcast message' do
         expect { perform :on_force_editing_started, interventionId: intervention.id }
           .to have_broadcasted_to("intervention_channel_#{intervention.id}")
-                .with({ data: { current_editor: { id: current_user.id, email: current_user.email, first_name: current_user.first_name,
-                                                  last_name: current_user.last_name }, topic: 'force_editing_started', status: 200 } })
+                .with({
+                        data: { current_editor: { id: current_user.id, email: current_user.email, first_name: current_user.first_name,
+                                                  last_name: current_user.last_name } }, topic: 'force_editing_started', status: 200
+                      })
       end
 
       context 'when current user isn\'t the owner' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3422](https://htdevelopers.atlassian.net/browse/CIAS30-3422)
- [CIAS-3420](https://htdevelopers.atlassian.net/browse/CIAS30-3420)

## What's new?
- broadcast message when sb leaves the channel
- fix issue when `left_joins` create duplicated user's rows 