### PR TITLE
[CIAS30-3425] block the ability to manage a logo beyond the current editor

### DIFF
--- a/app/controllers/v1/interventions/logos_controller.rb
+++ b/app/controllers/v1/interventions/logos_controller.rb
@@ -5,6 +5,7 @@ class V1::Interventions::LogosController < V1Controller
     authorize! :add_logo, Intervention
     authorize! :add_logo, intervention_load
     return render status: :method_not_allowed if intervention_published?
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     intervention_load.update!(logo: intervention_params[:file])
     invalidate_cache(intervention_load)
@@ -15,6 +16,7 @@ class V1::Interventions::LogosController < V1Controller
     authorize! :add_logo, Intervention
     authorize! :add_logo, intervention_load
     return render status: :method_not_allowed if intervention_published?
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     intervention_load.logo_blob&.update!(description: intervention_params[:image_alt])
     render json: serialized_response(intervention_load, 'Intervention')
@@ -24,6 +26,7 @@ class V1::Interventions::LogosController < V1Controller
     authorize! :add_logo, Intervention
     authorize! :add_logo, intervention_load
     return render status: :method_not_allowed if intervention_published?
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     intervention_load.logo.purge_later
     invalidate_cache(intervention_load)

--- a/spec/requests/v1/interventions/logos/create_spec.rb
+++ b/spec/requests/v1/interventions/logos/create_spec.rb
@@ -75,4 +75,29 @@ RSpec.describe 'POST /v1/interventions/:interventions_id/logo', type: :request d
       expect(response).to have_http_status(:forbidden)
     }
   end
+
+  context 'when collaborator has edit access' do
+    let(:intervention) { create(:intervention, :with_collaborators) }
+    let(:current_user) { intervention.collaborators.first.user }
+
+    before do
+      intervention.update(current_editor: current_user)
+      post v1_intervention_logo_path(intervention_id), params: params, headers: current_user.create_new_auth_token
+    end
+
+    it {
+      expect(response).to have_http_status(:created)
+    }
+
+    context 'when current editor is empty' do
+      before do
+        intervention.update(current_editor: nil)
+        post v1_intervention_logo_path(intervention_id), params: params, headers: current_user.create_new_auth_token
+      end
+
+      it {
+        expect(response).to have_http_status(:forbidden)
+      }
+    end
+  end
 end

--- a/spec/requests/v1/interventions/logos/destroy_spec.rb
+++ b/spec/requests/v1/interventions/logos/destroy_spec.rb
@@ -38,4 +38,30 @@ RSpec.describe 'DELETE /v1/interventions/:interventions_id/logo', type: :request
 
     it { expect(response).to have_http_status(:method_not_allowed) }
   end
+
+  context 'when collaborator has edit access' do
+    let(:intervention) { create(:intervention, :with_collaborators) }
+    let(:current_user) { intervention.collaborators.first.user }
+
+    before do
+      intervention.update(current_editor: current_user)
+      delete v1_intervention_logo_path(intervention_id), headers: current_user.create_new_auth_token
+    end
+
+    it {
+      expect(response).to have_http_status(:no_content)
+    }
+
+    context 'when current editor is empty' do
+      before do
+        intervention.update(current_editor: nil)
+
+        delete v1_intervention_logo_path(intervention.id), headers: current_user.create_new_auth_token
+      end
+
+      it {
+        expect(response).to have_http_status(:forbidden)
+      }
+    end
+  end
 end

--- a/spec/requests/v1/interventions/logos/update_spec.rb
+++ b/spec/requests/v1/interventions/logos/update_spec.rb
@@ -65,4 +65,29 @@ RSpec.describe 'PATCH  /v1/interventions/:interventions_id/logo', type: :request
       expect(response).to have_http_status(:forbidden)
     }
   end
+
+  context 'when collaborator has edit access' do
+    let(:intervention) { create(:intervention, :with_collaborators) }
+    let(:current_user) { intervention.collaborators.first.user }
+
+    before do
+      intervention.update(current_editor: current_user)
+    end
+
+    it {
+      request
+      expect(response).to have_http_status(:ok)
+    }
+
+    context 'when current editor is empty' do
+      before do
+        intervention.update(current_editor: nil)
+        request
+      end
+
+      it {
+        expect(response).to have_http_status(:forbidden)
+      }
+    end
+  end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3425](https://htdevelopers.atlassian.net/browse/CIAS30-3425)

## What's new?
- block the ability to manage a logo beyond the current editor 
- add tests to cover new part of code 
