### PR TITLE
[CIAS30-3430] User can edit navigator settings without being current editor

### DIFF
--- a/app/controllers/v1/live_chat/interventions/files_controller.rb
+++ b/app/controllers/v1/live_chat/interventions/files_controller.rb
@@ -4,6 +4,7 @@ class V1::LiveChat::Interventions::FilesController < V1Controller
   def create
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     return render status: :payload_too_large if files_too_big?
 
@@ -14,6 +15,7 @@ class V1::LiveChat::Interventions::FilesController < V1Controller
   def destroy
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     selected_files(params[:files_for]).find(file_id).purge_later
 

--- a/app/controllers/v1/live_chat/interventions/links_controller.rb
+++ b/app/controllers/v1/live_chat/interventions/links_controller.rb
@@ -4,6 +4,7 @@ class V1::LiveChat::Interventions::LinksController < V1Controller
   def update
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     link = link_load
     link.update!(link_params)
@@ -13,6 +14,7 @@ class V1::LiveChat::Interventions::LinksController < V1Controller
   def create
     authorize! :update, Intervention
     authorize! :create, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     navigator_setup = setup_load
     LiveChat::Interventions::Link.create!(link_params.merge(navigator_setup_id: navigator_setup.id))
@@ -23,6 +25,7 @@ class V1::LiveChat::Interventions::LinksController < V1Controller
   def destroy
     authorize! :delete, LiveChat::Interventions::Link
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     link_load&.destroy
     head :ok

--- a/app/controllers/v1/live_chat/interventions/navigator_setups_controller.rb
+++ b/app/controllers/v1/live_chat/interventions/navigator_setups_controller.rb
@@ -11,6 +11,7 @@ class V1::LiveChat::Interventions::NavigatorSetupsController < V1Controller
   def update
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     setup = navigator_setup_load
     V1::LiveChat::Interventions::UpdateNavigatorSetupService.call(setup, navigator_setup_params)

--- a/app/controllers/v1/live_chat/interventions/navigators_controller.rb
+++ b/app/controllers/v1/live_chat/interventions/navigators_controller.rb
@@ -9,6 +9,7 @@ class V1::LiveChat::Interventions::NavigatorsController < V1Controller
 
   def create
     authorize! :update, Intervention
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     added_navigator = V1::LiveChat::Interventions::Navigators::Assign.call(navigator_id, intervention_load)
     render json: navigators_response(added_navigator)
@@ -16,6 +17,7 @@ class V1::LiveChat::Interventions::NavigatorsController < V1Controller
 
   def destroy
     authorize! :update, Intervention
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     navigator = intervention_load.intervention_navigators.find_by!(user_id: intervention_navigator_id)
     ActiveRecord::Base.transaction do

--- a/app/controllers/v1/live_chat/navigators/invitations_controller.rb
+++ b/app/controllers/v1/live_chat/navigators/invitations_controller.rb
@@ -13,6 +13,7 @@ class V1::LiveChat::Navigators::InvitationsController < V1Controller
   def create
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     created_invitations = V1::LiveChat::InviteNavigators.call(
       navigator_invitation_params[:emails].map(&:downcase),
@@ -25,6 +26,7 @@ class V1::LiveChat::Navigators::InvitationsController < V1Controller
   def destroy
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     not_accepted_invitations.find(invitation_id).destroy
     render status: :ok

--- a/spec/requests/v1/live_chat/interventions/navigator_invitations/create_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/navigator_invitations/create_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe 'POST /v1/interventions/:intervention_id/navigator_invitations', 
     end
   end
 
+  context 'Only current editor can create invitations in the intervention with collaborators' do
+    let(:params) do
+      {
+        navigator_invitation: {
+          emails: emails
+        }
+      }
+    end
+    let(:intervention) { create(:intervention, :with_collaborators, user: admin, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'Existed user cannot become a navigator' do
     let(:participant) { create(:user, :confirmed, :participant) }
     let(:params) do

--- a/spec/requests/v1/live_chat/interventions/navigator_invitations/destroy_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/navigator_invitations/destroy_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe 'DELETE /v1/interventions/:intervention_id/navigator_invitations/
     end
   end
 
+  context 'not current editor' do
+    let(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'other researcher' do
     let(:other_researcher) { create(:user, :researcher, :confirmed) }
     let(:headers) { other_researcher.create_new_auth_token }

--- a/spec/requests/v1/live_chat/interventions/navigator_setup/update_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/navigator_setup/update_spec.rb
@@ -186,6 +186,22 @@ RSpec.describe 'PATCH /v1/live_chat/intervention/:id/navigator_setups', type: :r
     end
   end
 
+  context 'intervention with collaborators and current editor isn\'t current editor' do
+    let(:intervention) { create(:intervention, :with_collaborators, :with_navigator_setup, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+    let(:params) do
+      {
+        navigator_setup: {
+          no_navigator_available_message: 'No navigators available at the moment'
+        }
+      }
+    end
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'sets phone to nil when phone sent as nil and phone is present' do
     let!(:intervention) { create(:intervention, :with_navigator_setup_and_phone, user: user) }
 

--- a/spec/requests/v1/live_chat/interventions/navigators/create_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/navigators/create_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe 'POST /v1/live_chat/intervention/:id/navigators', type: :request 
         )
       end
     end
+
+    context 'but isn\'t the current editor' do
+      let(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+
+      it { expect(response).to have_http_status(:forbidden) }
+    end
   end
 
   context 'other researcher' do

--- a/spec/requests/v1/live_chat/interventions/navigators/destroy_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/navigators/destroy_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe 'DELETE /v1/live_chat/intervention/:id/navigators/:navigator_id',
     end
   end
 
+  context 'not current editor' do
+    let(:intervention) { create(:intervention, :with_collaborators, user: admin, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'Incorrect params or intervention' do
     context 'Incorrect IDs' do
       let(:request) do

--- a/spec/requests/v1/live_chat/interventions/participant_links/create_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/participant_links/create_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe 'POST /v1/live_chat/intervention/:id/navigator_setups/links', typ
     end
   end
 
+  context 'only current editor can create invitations in the intervention with collaborators' do
+    let(:params) do
+      {
+        link: {
+          url: 'https://google.com',
+          display_name: 'University of Google'
+        }
+      }
+    end
+    let(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'invalid params' do
     context 'missing link data' do
       let(:params) { {} }

--- a/spec/requests/v1/live_chat/interventions/participant_links/destroy_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/participant_links/destroy_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe 'DELETE /v1/live_chat/intervention/:id/navigator_setups/participa
     end
   end
 
+  context 'only current editor can create invitations in the intervention with collaborators' do
+    let(:intervention) { create(:intervention, :with_collaborators, :with_navigator_setup, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'when researcher want to destroy the link from other researcher intervention' do
     let(:researcher) { create(:user, :researcher, :confirmed) }
     let(:headers) { researcher.create_new_auth_token }

--- a/spec/requests/v1/live_chat/interventions/participant_links/update_spec.rb
+++ b/spec/requests/v1/live_chat/interventions/participant_links/update_spec.rb
@@ -37,6 +37,23 @@ RSpec.describe 'PATCH /v1/live_chat/intervention/:id/navigator_setups/participan
     end
   end
 
+  context 'only current editor can create invitations in the intervention with collaborators' do
+    let(:params) do
+      {
+        link: {
+          url: 'https://bing.com',
+          display_name: 'That\'s a much better search engine'
+        }
+      }
+    end
+    let(:intervention) { create(:intervention, :with_collaborators, :with_navigator_setup, user: user, current_editor: create(:user, :researcher, :confirmed)) }
+
+    it {
+      request
+      expect(response).to have_http_status(:forbidden)
+    }
+  end
+
   context 'invalid params' do
     context 'missing link data' do
       let(:params) { {} }


### PR DESCRIPTION
## Related tasks
- [CIAS-3430](https://htdevelopers.atlassian.net/browse/CIAS30-3430)

## What's new?
- added check to all live chat controllers which return `forbidden` if the current user isn't a current editor 
- added tests to cover new parts of the code 
