### PR TITLE
[CIAS30-3431] enable entering edit mode for a published intervention

### DIFF
--- a/app/channels/intervention_channel.rb
+++ b/app/channels/intervention_channel.rb
@@ -21,7 +21,7 @@ class InterventionChannel < ApplicationCable::Channel
   def on_editing_started
     intervention = Intervention.find(params[:id])
 
-    raise_exception if intervention.current_editor_id.present? || intervention.published?
+    raise_exception if intervention.current_editor_id.present?
     raise_exception unless intervention.in?(accessible_interventions)
 
     assign_current_editor!(intervention)
@@ -38,7 +38,7 @@ class InterventionChannel < ApplicationCable::Channel
   def on_force_editing_started
     intervention = Intervention.find(params[:id])
 
-    raise_exception if intervention.user_id != current_user.id || intervention.published?
+    raise_exception if intervention.user_id != current_user.id
     raise_exception unless intervention.in?(accessible_interventions)
 
     assign_current_editor!(intervention)
@@ -55,7 +55,7 @@ class InterventionChannel < ApplicationCable::Channel
   def on_editing_stopped
     intervention = Intervention.find(params[:id])
 
-    raise_exception if intervention.current_editor_id != current_user.id || intervention.published?
+    raise_exception if intervention.current_editor_id != current_user.id
     raise_exception unless intervention.in?(accessible_interventions)
 
     purge_editor_and_create_notifications!(intervention)

--- a/app/controllers/v1/interventions_controller.rb
+++ b/app/controllers/v1/interventions_controller.rb
@@ -23,14 +23,11 @@ class V1::InterventionsController < V1Controller
   def update
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
-    intervention = intervention_load
-
-    return head :forbidden unless intervention.ability_to_update_for?(current_v1_user)
-
-    intervention.assign_attributes(intervention_params)
-    intervention.save!
-    render json: serialized_response(intervention)
+    intervention_load.assign_attributes(intervention_params)
+    intervention_load.save!
+    render json: serialized_response(intervention_load)
   end
 
   def clone
@@ -71,7 +68,7 @@ class V1::InterventionsController < V1Controller
   end
 
   def intervention_load
-    interventions_scope.find(params[:id])
+    @intervention_load ||= interventions_scope.find(params[:id])
   end
 
   def intervention_params

--- a/spec/channels/intervention_channel_spec.rb
+++ b/spec/channels/intervention_channel_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe InterventionChannel, type: :channel do
                       })
       end
 
+      context 'when the intervention is published' do
+        let(:intervention) { create(:intervention, :with_collaborators, :published, user: researcher) }
+
+        it 'update current editor' do
+          perform :on_editing_started, interventionId: intervention.id
+          expect(intervention.reload.current_editor_id).to eql(current_user.id)
+        end
+      end
+
       context 'when sb editing the intervention' do
         it 'reject action' do
           intervention.update(current_editor_id: intervention.collaborators.first.user_id)
@@ -76,6 +85,16 @@ RSpec.describe InterventionChannel, type: :channel do
         expect { perform :on_editing_stopped, interventionId: intervention.id }
           .to have_broadcasted_to("intervention_channel_#{intervention.id}")
                 .with({ data: {}, topic: 'editing_stopped', status: 200 })
+      end
+
+      context 'when the intervention is published' do
+        let(:intervention) { create(:intervention, :with_collaborators, :published, user: researcher, current_editor: current_user) }
+
+        it 'update current editor' do
+          subscribe id: intervention.id
+          perform :on_editing_stopped, interventionId: intervention.id
+          expect(intervention.reload.current_editor_id).to be_nil
+        end
       end
 
       context 'when sb editing the intervention' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3431](https://htdevelopers.atlassian.net/browse/CIAS30-3431)

## What's new?
- removed check if intervention is published. Thanks to that, we can assign the current editor to the published intervention and edit for example the status (from `published` to `archived`) 
- added two simple tests to cover changes
- small refactor `interventions#update` 
