### PR TITLE
[CIAS30-3439] Handle e-intervention admin accesses to interventions in their organization

### DIFF
--- a/spec/abilities/report_templates_spec.rb
+++ b/spec/abilities/report_templates_spec.rb
@@ -47,6 +47,12 @@ describe ReportTemplate do
       it { should have_abilities(:manage, described_class) }
     end
 
+    context 'e-intervention admin' do
+      let(:user) { build_stubbed(:user, :confirmed, :e_intervention_admin) }
+
+      it { should have_abilities(:read, described_class) }
+    end
+
     context 'collaborator' do
       let(:collaborator) { create(:user, :confirmed, :researcher) }
       let(:intervention) { create(:intervention) }

--- a/spec/abilities/sessions_spec.rb
+++ b/spec/abilities/sessions_spec.rb
@@ -67,6 +67,16 @@ describe Session do
         expect(subject).to have_abilities({ manage: false }, team2_session1)
       end
     end
+
+    context 'e-intervention admin' do
+      let!(:organization) { create(:organization, :with_organization_admin, :with_e_intervention_admin) }
+      let!(:session) { create(:session, intervention: create(:intervention, organization: organization)) }
+      let(:user) { organization.e_intervention_admins.first }
+
+      it 'can read his session' do
+        expect(subject).to have_abilities({ read: true }, session)
+      end
+    end
   end
 
   describe '#accessible_by' do

--- a/spec/abilities/sms_plans_spec.rb
+++ b/spec/abilities/sms_plans_spec.rb
@@ -58,6 +58,12 @@ describe SmsPlan do
       it { should have_abilities(:manage, described_class) }
     end
 
+    context 'e-intervention admin' do
+      let(:user) { build_stubbed(:user, :confirmed, :e_intervention_admin) }
+
+      it { should have_abilities(:read, described_class) }
+    end
+
     context 'participant' do
       let(:user) { build_stubbed(:user, :confirmed, :participant) }
 


### PR DESCRIPTION
## Related tasks
- [CIAS-3439](https://htdevelopers.atlassian.net/browse/CIAS30-3439)

## What's new?
- added missing rules to e-int admin's ability(among others: fetch report templates, sms-es, sessions)
- added some tests to cover this case
