### PR TITLE
[CIAS30-3494] customize error message

### DIFF
--- a/app/models/collaborator.rb
+++ b/app/models/collaborator.rb
@@ -5,5 +5,5 @@ class Collaborator < ApplicationRecord
   belongs_to :intervention, touch: true
   belongs_to :user
 
-  validates :user_id, uniqueness: { scope: :intervention_id }
+  validates :user_id, uniqueness: { scope: :intervention_id, message: I18n.t('activerecord.errors.models.collaborator.attributes.user.already_exist') }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,10 @@ en:
   activerecord:
     errors:
       models:
+        collaborator:
+          attributes:
+            user:
+              already_exist: 'is already a collaborator in this intervention'
         intervention:
           attributes:
             cat_mh_resources: "Session with id=%{session_id} must contains cat_mh_language_id, cat_mh_population_id, cat_mh_time_frame_id, test_types, ERROR_FLAG:CatMhSessionInvalid"

--- a/spec/requests/v1/interventions/collaborators/create_spec.rb
+++ b/spec/requests/v1/interventions/collaborators/create_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe 'POST /v1/interventions/:intervention_id/collaborators', type: :r
     end
   end
 
+  context 'when the collaborator is already in this intervention' do
+    let(:intervention) { create(:intervention, :with_collaborators, user: user) }
+
+    let(:params) do
+      {
+        emails: [intervention.collaborators.first.user.email]
+      }
+    end
+
+    it 'return correct status' do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'has correct error msg' do
+      expect(json_response['message']).to include I18n.t('activerecord.errors.models.collaborator.attributes.user.already_exist')
+    end
+  end
+
   context 'when collaborator wants to add another collaborator' do
     let(:intervention) { create(:intervention, :with_collaborators, user: user) }
     let(:current_user) { intervention.collaborators.first.user }


### PR DESCRIPTION
## Related tasks
- [CIAS-3494](https://htdevelopers.atlassian.net/browse/CIAS30-3494)

## What's new?
- replace the default error msg with `Validation failed: User is already a collaborator in this intervention`
