### PR TITLE
[CIAS30-3505]: Adjust the error message, so it will not only mention the T&C and Privacy Policy, but also a First/Last name 

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
             collaborators:
               data_access: "Only owner can change 'data_access' parameter"
         user:
-          terms_not_accepted: 'If you want to login, you need accept terms and conditions & Privacy Policy first. Please find your invitation email or contact support'
+          terms_not_accepted: 'If you want to login, you need to enter your first and last name, as well as accept terms and conditions & Privacy Policy first. Please find your invitation email or contact support'
           2fa_code_needed: 'You need to provide 2fa code to verify you.'
           not_using_invitation_link: "If you want to register by this email, please use the registration link received by email from the researcher."
           attributes:


### PR DESCRIPTION
## Related tasks
- [CIAS-3505](https://htdevelopers.atlassian.net/browse/CIAS30-3505)

## What's new?
- Added the info about the first and last name in the error message
