### PR TITLE
Cias30 3384

### DIFF
--- a/app/jobs/clone_jobs/session.rb
+++ b/app/jobs/clone_jobs/session.rb
@@ -5,7 +5,7 @@ class CloneJobs::Session < CloneJob
     intervention = session.intervention
     position = intervention.sessions.order(:position).last.position + 1
     params = { variable: "cloned_#{session.variable}_#{position}" }
-    cloned_session = session.clone(params: params)
+    cloned_session = session.clone(params: params, clean_formulas: false)
 
     return unless user.email_notification
 

--- a/app/models/concerns/clone/session.rb
+++ b/app/models/concerns/clone/session.rb
@@ -4,7 +4,7 @@ class Clone::Session < Clone::Base
   def execute
     outcome.position = position || outcome.intervention.sessions.size
     outcome.clear_formulas if clean_formulas
-    outcome.days_after_date_variable_name = nil
+    outcome.days_after_date_variable_name = nil if clean_formulas
     ActiveRecord::Base.transaction do
       create_question_groups
       outcome.save!

--- a/spec/jobs/clone_jobs/session_spec.rb
+++ b/spec/jobs/clone_jobs/session_spec.rb
@@ -147,16 +147,13 @@ RSpec.describe CloneJobs::Session, type: :job do
         expect(cloned_session.position).to be(3)
       end
 
-      it 'has cleared formula' do
-        expect(cloned_session.attributes['formulas']).to include(
-          'payload' => '',
-          'patterns' => []
-        )
-        expect(cloned_session.attributes['settings']['formula']).to eq(false)
+      it 'has kept the formula' do
+        expect(cloned_session.attributes['formulas']).to eq(session.attributes['formulas'])
+        expect(cloned_session.attributes['settings']['formula']).to eq(session.attributes['settings']['formula'])
       end
 
-      it 'has cleared days_after_variable_name value' do
-        expect(cloned_session.attributes['days_after_date_variable_name']).to eq(nil)
+      it 'has not cleared days_after_variable_name value' do
+        expect(cloned_session.attributes['days_after_date_variable_name']).to eq(session.attributes['days_after_date_variable_name'])
       end
 
       it 'has correct number of question groups' do

--- a/spec/jobs/duplicate_jobs/session_spec.rb
+++ b/spec/jobs/duplicate_jobs/session_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe DuplicateJobs::Session, type: :job do
         'patterns' => []
       )
     end
+
+    it 'clears the days_after_variable_name value' do
+      expect(new_intervention.reload.sessions.first['days_after_date_variable_name']).to eq(nil)
+    end
   end
 
   context 'when new intervention does\'t exist' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3384](https://htdevelopers.atlassian.net/browse/CIAS30-3384)

## What's new?
- formulas and `days_after_date_variable_name` for session will only get cleaned when a session is shared internally to a different intervention
- when copying a whole intervention, or when cloning a session into the same intervention, these values will be kept
