### PR TITLE
[CIAS30-3522] move non-registered participants to login-page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,7 +246,7 @@ en:
       header: 'Your copy of %{intervention_name} is ready'
       body: 'Your intervention has been copied successfully. Now you can use it in CIAS.'
       button_text: Open the e-intervention
-      link: '%{web_url}/interventions/%{intervention_id}'
+      link: '%{web_url}/login?redirect_to=/interventions/%{intervention_id}'
     intervention_activate:
       subject: 'CIAS invitation'
       header: 'Welcome to CIAS'


### PR DESCRIPTION
## Related tasks
- [CIAS-3522](https://htdevelopers.atlassian.net/browse/CIAS30-3522)

## What's new?
- When an invited registered user collaborates, the email link should directly redirect non-logged-in users to the login page
- changed the link in en.yml
