### PR TITLE
different way to generate url in Channel

### DIFF
--- a/app/channels/intervention_channel.rb
+++ b/app/channels/intervention_channel.rb
@@ -102,7 +102,7 @@ class InterventionChannel < ApplicationCable::Channel
       user_id: user.id,
       first_name: user.first_name,
       last_name: user.last_name,
-      avatar_url: user.avatar.attached? ? polymorphic_url(object.avatar) : ''
+      avatar_url: user.avatar.attached? ? Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true) : ''
     }
   end
 


### PR DESCRIPTION
## Related tasks
- [CIAS-3523](https://htdevelopers.atlassian.net/browse/CIAS30-3523)

## What's new?
- In Action Cable, you cannot directly use url_for like you would in a typical Rails controller or view context. This is because Action Cable operates on WebSocket connections, which do not have a direct HTTP request/response cycle, and therefore don't have access to routing helpers like url_for.
