### PR TITLE
[CIAS30-3539] Started flag is not set to TRUE when participant is redirected to next session by "Start session immediately after previous session completion" option

### DIFF
--- a/app/services/v1/flow_service/schedule_service.rb
+++ b/app/services/v1/flow_service/schedule_service.rb
@@ -15,6 +15,8 @@ class V1::FlowService::ScheduleService
     return question unless next_session.present? && next_session.schedule_immediately?
 
     next_user_session = next_user_session!(next_session)
+    next_user_session.update!(started: true)
+
     user_session.finish(send_email: false)
     additional_information[:next_user_session_id] = next_user_session.id
     additional_information[:next_session_id] = next_user_session.session.id


### PR DESCRIPTION
## Related tasks
- [CIAS-3539](https://htdevelopers.atlassian.net/browse/CIAS30-3539)

## What's new?
- the `started` flag is now set properly to `true` when starting next session immidiately
