### PR TITLE
[CIAS-3538] change the status after rendering a response

### DIFF
--- a/app/controllers/v1/user_sessions_controller.rb
+++ b/app/controllers/v1/user_sessions_controller.rb
@@ -18,6 +18,8 @@ class V1::UserSessionsController < V1Controller
     user_session = V1::UserSessions::FetchService.call(params[:session_id], current_v1_user.id, params[:health_clinic_id])
 
     render json: serialized_response(user_session), status: :ok
+
+    user_session.update!(started: true)
   end
 
   def show_or_create

--- a/app/services/v1/user_sessions/fetch_service.rb
+++ b/app/services/v1/user_sessions/fetch_service.rb
@@ -22,7 +22,6 @@ class V1::UserSessions::FetchService < V1::UserSessions::BaseService
                         find_user_session(:find_by!)
                       end
 
-    @user_session.update!(started: true)
     @user_session
   end
 end

--- a/spec/requests/v1/user_sessions/show_spec.rb
+++ b/spec/requests/v1/user_sessions/show_spec.rb
@@ -71,8 +71,12 @@ RSpec.describe 'GET /v1/user_sessions', type: :request do
       expect(json_response['data']['id']).to eq user_session.id
     end
 
-    it 'has the "started" flag set to true' do
-      expect(json_response['data']['attributes']['started']).to be true
+    it 'has the "started" flag set to false' do
+      expect(json_response['data']['attributes']['started']).to be false
+    end
+
+    it 'user session has the "started" flag set to true' do
+      expect(user_session.reload.started).to be true
     end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3538](https://htdevelopers.atlassian.net/browse/CIAS30-3538)

## What's new?
- Status change only after the response is returned
