### PR TITLE
[CIAS30-3540] change the status of the user intervention after creating a user session

### DIFF
--- a/app/services/v1/user_sessions/create_service.rb
+++ b/app/services/v1/user_sessions/create_service.rb
@@ -8,6 +8,8 @@ class V1::UserSessions::CreateService < V1::UserSessions::BaseService
       health_clinic_id: health_clinic_id
     )
 
+    @user_intervention.in_progress!
+
     new_user_session_for(:new, number_of_attempts)
   end
 end

--- a/spec/services/v1/user_sessions/create_service_spec.rb
+++ b/spec/services/v1/user_sessions/create_service_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe V1::UserSessions::CreateService do
   let(:user_id) { user.id }
   let(:session_id) { session.id }
 
-  # before do
-  #   allow(UserSession).to receive(:new).and_return(true)
-  # end
-
   context 'when user session and user intervention do not exist' do
     it 'create user intervention' do
       expect { subject }.to change(UserIntervention, :count).by(1)
+    end
+
+    it 'new user intervention has correct status' do
+      expect(subject.user_intervention.reload.status).to eql('in_progress')
     end
 
     it 'instantiate user session' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3540](https://htdevelopers.atlassian.net/browse/CIAS30-3540)

## What's new?
- The creation of a session user is a clear indication that the intervention has begun. The presented situation should be mapped with the correct status. Therefore, after creating a user session, the status is set to "in_progress". 
