### PR TITLE
[CIAS30-3551] refactor the tests for deleting report logos (extract shared examples)

### DIFF
--- a/spec/requests/v1/report_templates/delete_custom_logo_spec.rb
+++ b/spec/requests/v1/report_templates/delete_custom_logo_spec.rb
@@ -17,42 +17,20 @@ RSpec.describe 'DELETE v1/sessions/:session_id/report_templates/:id/remove_cover
 
   let!(:report_template) { create(:report_template, :with_custom_cover_letter_logo, session: session) }
 
-  shared_examples 'can delete the custom cover page logo' do
-    it 'returns the response code for no content' do
-      request
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it 'removes the attachment' do
-      expect { request }.to change(ActiveStorage::Attachment, :count).by(-1)
-    end
-  end
-
-  shared_examples 'cannot delete the custom cover page logo' do
-    it 'rejects the request' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it 'does not delete any attachments' do
-      expect { request }.not_to change(ActiveStorage::Attachment, :count)
-    end
-  end
-
   context 'when an admin deletes the custom cover letter logo' do
     let!(:user) { create(:user, :admin, :confirmed) }
 
-    it_behaves_like 'can delete the custom cover page logo'
+    it_behaves_like 'can delete attachment'
   end
 
   context 'when a researcher tries to delete the custom logo of a session which is not theirs' do
-    it_behaves_like 'cannot delete the custom cover page logo'
+    it_behaves_like 'cannot delete attachment'
   end
 
   context 'when a participant tries to delete the custom cover letter logo of their session' do
     let!(:intervention) { create(:intervention, user: user) }
 
-    it_behaves_like 'can delete the custom cover page logo'
+    it_behaves_like 'can delete attachment'
   end
 
   context 'when the report is for a collaborative session' do
@@ -61,14 +39,14 @@ RSpec.describe 'DELETE v1/sessions/:session_id/report_templates/:id/remove_cover
     context 'when the user is the current editor' do
       let!(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: user) }
 
-      it_behaves_like 'can delete the custom cover page logo'
+      it_behaves_like 'can delete attachment'
     end
 
     context 'when the user is not the current editor' do
       let(:other_user) { create(:user, :researcher, :confirmed) }
       let!(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: other_user) }
 
-      it_behaves_like 'cannot delete the custom cover page logo'
+      it_behaves_like 'cannot delete attachment'
     end
   end
 end

--- a/spec/requests/v1/report_templates/delete_logo_spec.rb
+++ b/spec/requests/v1/report_templates/delete_logo_spec.rb
@@ -17,42 +17,20 @@ RSpec.describe 'DELETE v1/sessions/:session_id/report_templates/:id/remove_logo'
 
   let!(:report_template) { create(:report_template, :with_logo, session: session) }
 
-  shared_examples 'can delete the report logo' do
-    it 'returns the response code for no content' do
-      request
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it 'removes the attachment' do
-      expect { request }.to change(ActiveStorage::Attachment, :count).by(-1)
-    end
-  end
-
-  shared_examples 'cannot delete the report logo' do
-    it 'rejects the request' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it 'does not delete any attachments' do
-      expect { request }.not_to change(ActiveStorage::Attachment, :count)
-    end
-  end
-
   context 'when an admin deletes the report logo' do
     let!(:user) { create(:user, :admin, :confirmed) }
 
-    it_behaves_like 'can delete the report logo'
+    it_behaves_like 'can delete attachment'
   end
 
   context 'when a researcher tries to delete the custom logo of a session which is not theirs' do
-    it_behaves_like 'cannot delete the report logo'
+    it_behaves_like 'cannot delete attachment'
   end
 
   context 'when a participant tries to delete the report logo of their session' do
     let!(:intervention) { create(:intervention, user: user) }
 
-    it_behaves_like 'can delete the report logo'
+    it_behaves_like 'can delete attachment'
   end
 
   context 'when the report is for a collaborative session' do
@@ -61,14 +39,14 @@ RSpec.describe 'DELETE v1/sessions/:session_id/report_templates/:id/remove_logo'
     context 'when the user is the current editor' do
       let!(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: user) }
 
-      it_behaves_like 'can delete the report logo'
+      it_behaves_like 'can delete attachment'
     end
 
     context 'when the user is not the current editor' do
       let(:other_user) { create(:user, :researcher, :confirmed) }
       let!(:intervention) { create(:intervention, :with_collaborators, user: user, current_editor: other_user) }
 
-      it_behaves_like 'cannot delete the report logo'
+      it_behaves_like 'cannot delete attachment'
     end
   end
 end

--- a/spec/support/shared_examples/deleting_attachment.rb
+++ b/spec/support/shared_examples/deleting_attachment.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'can delete attachment' do
+  it 'returns the response code for no content' do
+    request
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it 'removes the attachment' do
+    expect { request }.to change(ActiveStorage::Attachment, :count).by(-1)
+  end
+end
+
+RSpec.shared_examples 'cannot delete attachment' do
+  it 'rejects the request' do
+    request
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'does not delete any attachments' do
+    expect { request }.not_to change(ActiveStorage::Attachment, :count)
+  end
+end


### PR DESCRIPTION
## Related tasks
- [CIAS-3551](https://htdevelopers.atlassian.net/browse/CIAS30-3551)

## What's new?
- The shared example groups for deleting attachments are now used both for removing report template logo and custom cover page logo
