### PR TITLE
[CIAS30-3535] add a flag to intervention to check whether it was cleared

### DIFF
--- a/app/models/concerns/clone/intervention.rb
+++ b/app/models/concerns/clone/intervention.rb
@@ -3,6 +3,7 @@
 class Clone::Intervention < Clone::Base
   def execute
     outcome.status = :draft
+    outcome.cleared = false
     outcome.name = "Copy of #{outcome.name}"
     outcome.is_hidden = true
     clear_organization!

--- a/app/serializers/v1/intervention_serializer.rb
+++ b/app/serializers/v1/intervention_serializer.rb
@@ -4,7 +4,7 @@ class V1::InterventionSerializer < V1Serializer
   include FileHelper
   include TeamCollaboratorsHelper
 
-  attributes :id, :user_id, :type, :name, :status, :shared_to, :organization_id, :google_language_id, :created_at, :updated_at, :published_at,
+  attributes :id, :user_id, :type, :name, :status, :shared_to, :organization_id, :google_language_id, :created_at, :updated_at, :published_at, :cleared,
              :cat_mh_application_id, :cat_mh_organization_id, :cat_mh_pool, :created_cat_mh_session_count, :license_type, :is_access_revoked,
              :additional_text, :original_text, :quick_exit, :current_narrator, :live_chat_enabled
 

--- a/app/serializers/v1/simple_intervention_serializer.rb
+++ b/app/serializers/v1/simple_intervention_serializer.rb
@@ -2,7 +2,7 @@
 
 class V1::SimpleInterventionSerializer < V1Serializer
   include TeamCollaboratorsHelper
-  attributes :id, :user_id, :name, :status, :created_at, :updated_at, :organization_id, :google_language_id
+  attributes :id, :user_id, :name, :status, :cleared, :created_at, :updated_at, :organization_id, :google_language_id
 
   cache_options(store: Rails.cache, namespace: 'simple-intervention-serializer', expires_in: 24.hours)  # temporary length, might be a subject to change
 

--- a/db/migrate/20230804104852_add_cleared_flag_for_intervention.rb
+++ b/db/migrate/20230804104852_add_cleared_flag_for_intervention.rb
@@ -1,0 +1,5 @@
+class AddClearedFlagForIntervention < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:interventions, :cleared, :boolean, null: false, default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_20_080937) do
+ActiveRecord::Schema.define(version: 2023_08_04_104852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -410,6 +410,7 @@ ActiveRecord::Schema.define(version: 2023_07_20_080937) do
     t.integer "current_narrator", default: 0
     t.uuid "current_editor_id"
     t.integer "conversations_count"
+    t.boolean "cleared", default: false, null: false
     t.index ["current_editor_id"], name: "index_interventions_on_current_editor_id"
     t.index ["google_language_id"], name: "index_interventions_on_google_language_id"
     t.index ["name", "user_id"], name: "index_interventions_on_name_and_user_id", using: :gin
@@ -619,6 +620,10 @@ ActiveRecord::Schema.define(version: 2023_07_20_080937) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "original_text"
+    t.boolean "has_cover_letter", default: false, null: false
+    t.string "cover_letter_logo_type", default: "report_logo", null: false
+    t.string "cover_letter_description"
+    t.string "cover_letter_sender"
     t.index ["report_for"], name: "index_report_templates_on_report_for"
     t.index ["session_id", "name"], name: "index_report_templates_on_session_id_and_name", unique: true
     t.index ["session_id"], name: "index_report_templates_on_session_id"

--- a/spec/factories/interventions.rb
+++ b/spec/factories/interventions.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
     end
     shared_to { 'anyone' }
 
+    trait :cleared do
+      cleared { true }
+    end
+
     trait :with_navigator_setup do
       after(:build) do |intervention|
         intervention.live_chat_enabled = true

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -140,6 +140,15 @@ RSpec.describe Intervention, type: :model do
       expect(cloned_intervention.name).to include('Copy of')
     end
 
+    context 'when the intervention is cleared' do
+      let!(:intervention) { create(:intervention, :cleared) }
+
+      it 'sets the cleared flag to false' do
+        cloned_intervention = intervention.clone
+        expect(cloned_intervention.cleared).to eq(false)
+      end
+    end
+
     it 'remove short links' do
       cloned_intervention = intervention.clone
       expect(cloned_intervention.short_links.any?).to be false


### PR DESCRIPTION
## Related tasks
- [CIAS-3535](https://htdevelopers.atlassian.net/browse/CIAS30-3535)

## What's new?
- `Intervention` now has a new flag `cleared`, by default set to `false`
