### PR TITLE
[CIAS30-3568][CIAS30-3569] fixed bug with flag and removed restriction

### DIFF
--- a/app/controllers/v1/sessions/report_templates_controller.rb
+++ b/app/controllers/v1/sessions/report_templates_controller.rb
@@ -69,7 +69,7 @@ class V1::Sessions::ReportTemplatesController < V1Controller
 
   def duplicate
     authorize! :update, session
-    return head :forbidden unless target_session.ability_to_update_for?(current_v1_user)
+    return head :forbidden unless @session.ability_to_update_for?(current_v1_user)
 
     duplicated_report = report_template.clone(params: duplicate_params)
     Session.reset_counters(duplicated_report.session.id, :report_templates)

--- a/app/models/concerns/clone/report_template.rb
+++ b/app/models/concerns/clone/report_template.rb
@@ -17,7 +17,7 @@ class Clone::ReportTemplate
   end
 
   def execute
-    outcome.is_duplicated_from_other_session = true if different_session? && set_flag
+    outcome.update!(is_duplicated_from_other_session: true) if different_session? && set_flag
     clone_attachments
 
     source.sections.each do |section|

--- a/spec/models/report_template_spec.rb
+++ b/spec/models/report_template_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ReportTemplate, type: :model do
       end
 
       it 'has "is_duplicated_from_other_session" flag on' do
-        expect(subject.is_duplicated_from_other_session).to eq(true)
+        expect(subject.reload.is_duplicated_from_other_session).to eq(true)
       end
 
       context 'when the option to set flag is off' do

--- a/spec/requests/v1/report_templates/duplicate_spec.rb
+++ b/spec/requests/v1/report_templates/duplicate_spec.rb
@@ -57,5 +57,24 @@ RSpec.describe 'POST /v1/sessions/:session_id/report_templates/:report_template_
         expect(session2.report_templates.count).to be(1)
       end
     end
+
+    context 'duplicate report to other session in the another intervention' do
+      let(:another_session) { create(:session) }
+      let(:params) { { report_template: { session_id: another_session.id } } }
+
+      it 'return created' do
+        request
+        expect(response).to have_http_status(:created)
+      end
+
+      context 'when session belongs to intervention with collaborators' do
+        let(:another_session) { create(:session, intervention: create(:intervention, :with_collaborators)) }
+
+        it 'return created' do
+          request
+          expect(response).to have_http_status(:created)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3568](https://htdevelopers.atlassian.net/browse/CIAS30-3568)
- [CIAS-3569](https://htdevelopers.atlassian.net/browse/CIAS30-3569)

## What's new?
- The flag wasn't saved into the DB 
- removed the restriction that a researcher can't duplicate internally any report template to the session in another intervention with collaborators 