### PR TITLE
[CIAS30-3574] add filtering interventions by whether they were starred

### DIFF
--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -221,7 +221,7 @@ class Intervention < ApplicationRecord
   end
 
   def self.filter_if_starred(params, user)
-    case params.fetch(:starred)
+    case params[:starred]
     when 'true'
       all.only_starred_by_me(user)
     when 'false'

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -149,7 +149,7 @@ class Intervention < ApplicationRecord
     scope = filter_by_collaboration_type(params, user)
     scope = scope.limit_to_statuses(params[:statuses])
     scope = scope.filter_by_organization(params[:organization_id]) if params[:organization_id].present?
-    scope = scope.filter_if_starred(params[:starred], user) if params[:starred].present?
+    scope = scope.filter_if_starred(params, user)
     scope.filter_by_name(params[:name])
   end
 

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -147,6 +147,7 @@ class Intervention < ApplicationRecord
     scope = filter_by_collaboration_type(params, user)
     scope = scope.limit_to_statuses(params[:statuses])
     scope = scope.filter_by_organization(params[:organization_id]) if params[:organization_id].present?
+    scope = scope.filter_if_starred(params[:starred], user) if params[:starred].present?
     scope.filter_by_name(params[:name])
   end
 
@@ -215,5 +216,14 @@ class Intervention < ApplicationRecord
     scope = scope.only_shared_by_me(user.id) if params[:only_shared_by_me].present?
     scope = scope.only_not_shared_with_anyone(user.id) if params[:only_not_shared_with_anyone].present?
     scope
+  end
+
+  def self.filter_if_starred(starred, user)
+    starred_interventions_ids = user.stars.pluck(:intervention_id)
+    if starred == 'true'
+      all.where(id: starred_interventions_ids)
+    else
+      all.where.not(id: starred_interventions_ids)
+    end
   end
 end

--- a/spec/requests/v1/interventions/index_spec.rb
+++ b/spec/requests/v1/interventions/index_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe 'GET /v1/interventions', type: :request do
   end
 
   # make sure its independent of stars of other users
-  (a = [false, true]).product(a).each do |flag1, flag2|
+  ([false, true]).product([false, true]).each do |flag1, flag2|
     context 'when filtering by whether an intervention is starred' do
       let!(:starred_intervention) { create(:intervention, user: user) }
       let!(:not_starred_intervention) { create(:intervention, user: user) }
@@ -261,8 +261,7 @@ RSpec.describe 'GET /v1/interventions', type: :request do
     end
 
     it 'lists the starred interventions before the unstarred ones' do
-      expect(json_response['data'].pluck('id')).to eq(correct_index_order.map { |index| interventions[index].id })
-    end
+      expect(json_response['data'].pluck('id')).to eq(correct_index_order.map { |index| interventions[index].id }) end
 
     context 'when other user with access to the interventions will have other interventions starred' do
       let(:other_admin) { create(:user, :confirmed, :admin) }

--- a/spec/requests/v1/interventions/index_spec.rb
+++ b/spec/requests/v1/interventions/index_spec.rb
@@ -201,6 +201,40 @@ RSpec.describe 'GET /v1/interventions', type: :request do
     end
   end
 
+  context 'when filtering by whether an intervention is starred' do
+    let!(:starred_intervention) { create(:intervention, user: user) }
+    let!(:not_starred_intervention) { create(:intervention, user: user) }
+
+    before do
+      Star.create(user_id: user.id, intervention_id: starred_intervention.id)
+      get v1_interventions_path, params: params, headers: user.create_new_auth_token
+    end
+
+    context 'return all interventions when starred not specified' do
+      let(:params) { {} }
+
+      it 'returns correct interventions' do
+        expect(json_response['data'].pluck('id')).to include(starred_intervention.id).and include(not_starred_intervention.id)
+      end
+    end
+
+    context 'return only starred interventions' do
+      let(:params) { { starred: true } }
+
+      it 'returns correct interventions' do
+        expect(json_response['data'].pluck('id')).to include(starred_intervention.id).and not_include(not_starred_intervention.id)
+      end
+    end
+
+    context 'return only not starred interventions' do
+      let(:params) { { starred: false } }
+
+      it 'returns correct interventions' do
+        expect(json_response['data'].pluck('id')).to not_include(starred_intervention.id).and include(not_starred_intervention.id)
+      end
+    end
+  end
+
   context 'when some interventions are starred' do
     let(:other_researcher) { create(:user, :confirmed, :researcher) }
 

--- a/spec/requests/v1/interventions/index_spec.rb
+++ b/spec/requests/v1/interventions/index_spec.rb
@@ -261,7 +261,8 @@ RSpec.describe 'GET /v1/interventions', type: :request do
     end
 
     it 'lists the starred interventions before the unstarred ones' do
-      expect(json_response['data'].pluck('id')).to eq(correct_index_order.map { |index| interventions[index].id }) end
+      expect(json_response['data'].pluck('id')).to eq(correct_index_order.map { |index| interventions[index].id })
+    end
 
     context 'when other user with access to the interventions will have other interventions starred' do
       let(:other_admin) { create(:user, :confirmed, :admin) }

--- a/spec/requests/v1/interventions/index_spec.rb
+++ b/spec/requests/v1/interventions/index_spec.rb
@@ -229,14 +229,6 @@ RSpec.describe 'GET /v1/interventions', type: :request do
           expect(json_response['data'].pluck('id')).to include(starred_intervention.id).and not_include(not_starred_intervention.id)
         end
       end
-
-      context 'return only not starred interventions' do
-        let(:params) { { starred: false } }
-
-        it 'returns correct interventions' do
-          expect(json_response['data'].pluck('id')).to not_include(starred_intervention.id).and include(not_starred_intervention.id)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
## Related tasks
- [CIAS-3574](https://htdevelopers.atlassian.net/browse/CIAS30-3574)

## What's new?
- added new param for `v1/interventions` - `starred`
- having it defined will only return interventions starred by the current user
