### PR TITLE
[CIAS30-3567] Fix report template ids so they are correctly removed when changing the report template type

### DIFF
--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -24,7 +24,7 @@ class ReportTemplate < ApplicationRecord
 
   delegate :ability_to_update_for?, to: :session
 
-  before_update :remove_template_from_third_party_questions_if_report_is_for_participant
+  before_update :cascade_report_template_type_change
 
   after_destroy :remove_template_from_third_party_questions
 
@@ -65,7 +65,7 @@ class ReportTemplate < ApplicationRecord
     end
   end
 
-  def remove_template_from_third_party_questions_if_report_is_for_participant
+  def cascade_report_template_type_change
     remove_template_from_third_party_questions if report_for_was == 'third_party' && report_for != 'third_party'
   end
 end

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -24,6 +24,8 @@ class ReportTemplate < ApplicationRecord
 
   delegate :ability_to_update_for?, to: :session
 
+  before_update :remove_template_from_third_party_questions_if_report_is_for_participant
+
   after_destroy :remove_template_from_third_party_questions
 
   enum report_for: {
@@ -61,5 +63,9 @@ class ReportTemplate < ApplicationRecord
       end
       question.update!(body: question.body)
     end
+  end
+
+  def remove_template_from_third_party_questions_if_report_is_for_participant
+    remove_template_from_third_party_questions if report_for_was == 'third_party' && report_for != 'third_party'
   end
 end

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -66,6 +66,6 @@ class ReportTemplate < ApplicationRecord
   end
 
   def report_for_changed_from_third_party
-    changes_to_save['report_for'].first == 'third_party'
+    changes_to_save['report_for']&.first == 'third_party'
   end
 end

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -24,7 +24,7 @@ class ReportTemplate < ApplicationRecord
 
   delegate :ability_to_update_for?, to: :session
 
-  before_update :cascade_report_template_type_change
+  before_update :remove_template_from_third_party_questions, if: :report_for_changed_from_third_party
 
   after_destroy :remove_template_from_third_party_questions
 
@@ -65,7 +65,7 @@ class ReportTemplate < ApplicationRecord
     end
   end
 
-  def cascade_report_template_type_change
-    remove_template_from_third_party_questions if report_for_was == 'third_party' && report_for != 'third_party'
+  def report_for_changed_from_third_party
+    changes_to_save['report_for'].first == 'third_party'
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3567](https://htdevelopers.atlassian.net/browse/CIAS30-3567)

## What's new?
- when changing the `report_for` field for the report template from `third_party` to `participant` it will remove its id from the answers in the third party question type questions
- cloning a session will now simply omit any invalid ids, also it's optimized not to include an N+1 error
