### PR TITLE
[CIAS30-3617] Scheduled deletion job is started once again when the time of deletion come

### DIFF
--- a/db/migrate/20230829180239_remove_constraint_about_user_id_from_chart_statistics.rb
+++ b/db/migrate/20230829180239_remove_constraint_about_user_id_from_chart_statistics.rb
@@ -1,0 +1,5 @@
+class RemoveConstraintAboutUserIdFromChartStatistics < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :chart_statistics, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_15_122501) do
+ActiveRecord::Schema.define(version: 2023_08_29_180239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 2023_08_15_122501) do
     t.uuid "health_system_id", null: false
     t.uuid "health_clinic_id", null: false
     t.uuid "chart_id", null: false
-    t.uuid "user_id", null: false
+    t.uuid "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "filled_at"


### PR DESCRIPTION
## Related tasks
- [CIAS-3617](https://htdevelopers.atlassian.net/browse/CIAS30-3617)

## What's new?
- in the DB on the staging, we have some cases when we have guest users without any user session but have some chart statistics. In the model, we have set `has_many :chart_statistics, dependent: :nullify` which after calling `delete_quest_users_without_any_intervention!` in `DataClearJobs::ClearUserData` we have tried to put null in the chart statistic but in the schema we have defined that null isn't allowed 
