### PR TITLE
[CIAAS30-3627]fix issue with status for some type of scheduling

### DIFF
--- a/app/services/v1/user_session_schedule_service.rb
+++ b/app/services/v1/user_session_schedule_service.rb
@@ -86,6 +86,6 @@ class V1::UserSessionScheduleService
 
     user_intervention.update!(status: :schedule_pending)
     next_user_session.update!(scheduled_at: date_of_schedule)
-    SessionScheduleJob.set(wait_until: date_of_schedule).perform_later(next_session.id, user_session.user.id, health_clinic)
+    SessionScheduleJob.set(wait_until: date_of_schedule).perform_later(next_session.id, user_session.user.id, health_clinic, user_intervention.id)
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3627](https://htdevelopers.atlassian.net/browse/CIAS30-3627)

## What's new?
- passed missing parameter responsible for status of the user intervention
