### PR TITLE
[CIAS30-3653] Fix changing the type of intervention access not updating session scheduling parameters

### DIFF
--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -234,8 +234,10 @@ class Intervention < ApplicationRecord
     permitted_schedules = %w[after_fill immediately]
 
     sessions.each do |session|
+      next if session.schedule.in(permitted_schedules)
+
       session.update!(
-        schedule: session.schedule.in?(permitted_schedules) ? session.schedule : 'after_fill',
+        schedule: 'after_fill',
         schedule_payload: nil,
         schedule_at: nil
       )

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -234,7 +234,7 @@ class Intervention < ApplicationRecord
     permitted_schedules = %w[after_fill immediately]
 
     sessions.each do |session|
-      next if session.schedule.in(permitted_schedules)
+      next if session.schedule.in?(permitted_schedules)
 
       session.update!(
         schedule: 'after_fill',

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -78,7 +78,7 @@ class Intervention < ApplicationRecord
   before_validation :assign_default_google_language
   before_save :create_navigator_setup, if: -> { live_chat_enabled && navigator_setup.nil? }
   before_save :remove_short_links, if: :will_save_change_to_organization_id?
-  before_save :cascade_access_type_change, if: :will_save_change_to_shared_to?
+  before_update :cascade_access_type_change, if: :shared_to_changed?
   after_update_commit :status_change, :hf_access_change
 
   def assign_default_google_language

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -78,6 +78,7 @@ class Intervention < ApplicationRecord
   before_validation :assign_default_google_language
   before_save :create_navigator_setup, if: -> { live_chat_enabled && navigator_setup.nil? }
   before_save :remove_short_links, if: :will_save_change_to_organization_id?
+  before_save :cascade_access_type_change, if: :will_save_change_to_shared_to?
   after_update_commit :status_change, :hf_access_change
 
   def assign_default_google_language
@@ -225,6 +226,20 @@ class Intervention < ApplicationRecord
 
   def remove_short_links
     short_links.destroy_all
+  end
+
+  def cascade_access_type_change
+    return unless shared_to == 'anyone'
+
+    permitted_schedules = %w[after_fill immediately]
+
+    sessions.each do |session|
+      session.update!(
+        schedule: session.schedule.in?(permitted_schedules) ? session.schedule : 'after_fill',
+        schedule_payload: nil,
+        schedule_at: nil
+      )
+    end
   end
 
   def self.filter_by_collaboration_type(params, user)


### PR DESCRIPTION
## Related tasks
- [CIAS-3653](https://htdevelopers.atlassian.net/browse/CIAS30-3653)

## What's new?
- changing the type of sharing for an intervention to `anyone` will now change the scheduling type for all sessions of which their current scheduling mode wouldn't be applicable
