### PR TITLE
[CIAS30-3636] Delete predefined users when clearing intervention data

### DIFF
--- a/app/controllers/v1/interventions/predefined_participants_controller.rb
+++ b/app/controllers/v1/interventions/predefined_participants_controller.rb
@@ -16,16 +16,33 @@ class V1::Interventions::PredefinedParticipantsController < V1Controller
     render json: serialized_response(predefined_user), status: :created
   end
 
+  def update
+    authorize! :update, Intervention
+    authorize! :update, intervention_load
+
+    predefined_user = V1::Intervention::PredefinedParticipants::UpdateService.call(intervention_load, predefined_participant, predefined_user_parameters)
+
+    render json: serialized_response(predefined_user)
+  end
+
   def destroy; end
 
   private
+
+  def predefined_user_parameters
+    params.require(:predefined_user).permit(:first_name, :last_name, :health_clinic_id, phone_attributes: %i[iso prefix number])
+  end
 
   def intervention_load
     @intervention_load ||= Intervention.accessible_by(current_ability).find(intervention_id)
   end
 
-  def predefined_user_parameters
-    params.require(:predefined_user).permit(:first_name, :last_name, :health_clinic_id, phone_attributes: %i[iso prefix number])
+  def predefined_participants
+    @predefined_participants ||= intervention_load.predefined_users
+  end
+
+  def predefined_participant
+    @predefined_participant ||= predefined_participants.find(params[:id])
   end
 
   def intervention_id

--- a/app/controllers/v1/interventions/predefined_participants_controller.rb
+++ b/app/controllers/v1/interventions/predefined_participants_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# frozen_string_require: true
+
+class V1::Interventions::PredefinedParticipantsController < V1Controller
+  def show; end
+
+  def index; end
+
+  def create
+    authorize! :update, Intervention
+    authorize! :update, intervention_load
+
+    predefined_user = V1::Intervention::PredefinedParticipants::CreateService.call(intervention_load, predefined_user_parameters)
+
+    render json: serialized_response(predefined_user), status: :created
+  end
+
+  def destroy; end
+
+  private
+
+  def intervention_load
+    @intervention_load ||= Intervention.accessible_by(current_ability).find(intervention_id)
+  end
+
+  def predefined_user_parameters
+    params.require(:predefined_user).permit(:first_name, :last_name, :health_clinic_id, phone_attributes: %i[iso prefix number])
+  end
+
+  def intervention_id
+    params[:intervention_id]
+  end
+end

--- a/app/controllers/v1/interventions/predefined_participants_controller.rb
+++ b/app/controllers/v1/interventions/predefined_participants_controller.rb
@@ -37,8 +37,6 @@ class V1::Interventions::PredefinedParticipantsController < V1Controller
     render json: serialized_response(predefined_user)
   end
 
-  def destroy; end
-
   private
 
   def predefined_user_parameters

--- a/app/controllers/v1/interventions/predefined_participants_controller.rb
+++ b/app/controllers/v1/interventions/predefined_participants_controller.rb
@@ -3,9 +3,19 @@
 # frozen_string_require: true
 
 class V1::Interventions::PredefinedParticipantsController < V1Controller
-  def show; end
+  def show
+    authorize! :read, Intervention
+    authorize! :read, intervention_load
 
-  def index; end
+    render json: serialized_response(predefined_participant)
+  end
+
+  def index
+    authorize! :read, Intervention
+    authorize! :read, intervention_load
+
+    render json: serialized_response(predefined_participants)
+  end
 
   def create
     authorize! :update, Intervention
@@ -40,7 +50,7 @@ class V1::Interventions::PredefinedParticipantsController < V1Controller
   end
 
   def predefined_participants
-    @predefined_participants ||= intervention_load.predefined_users
+    @predefined_participants ||= intervention_load.predefined_users.includes(:predefined_user_parameter, :phone)
   end
 
   def predefined_participant

--- a/app/controllers/v1/interventions/predefined_participants_controller.rb
+++ b/app/controllers/v1/interventions/predefined_participants_controller.rb
@@ -10,6 +10,7 @@ class V1::Interventions::PredefinedParticipantsController < V1Controller
   def create
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     predefined_user = V1::Intervention::PredefinedParticipants::CreateService.call(intervention_load, predefined_user_parameters)
 
@@ -19,6 +20,7 @@ class V1::Interventions::PredefinedParticipantsController < V1Controller
   def update
     authorize! :update, Intervention
     authorize! :update, intervention_load
+    return head :forbidden unless intervention_load.ability_to_update_for?(current_v1_user)
 
     predefined_user = V1::Intervention::PredefinedParticipants::UpdateService.call(intervention_load, predefined_participant, predefined_user_parameters)
 

--- a/app/jobs/data_clear_jobs/clear_user_data.rb
+++ b/app/jobs/data_clear_jobs/clear_user_data.rb
@@ -8,7 +8,7 @@ class DataClearJobs::ClearUserData < ApplicationJob
       intervention.user_interventions.destroy_all
       intervention.conversations.destroy_all
       intervention.conversations_transcript.destroy
-      delete_quest_users_without_any_intervention!
+      delete_temporary_users_without_any_intervention!
 
       intervention.sensitive_data_removed!
       create_notification!(intervention)
@@ -17,8 +17,9 @@ class DataClearJobs::ClearUserData < ApplicationJob
 
   private
 
-  def delete_quest_users_without_any_intervention!
+  def delete_temporary_users_without_any_intervention!
     User.left_joins(:user_interventions).where(roles: ['guest'], user_interventions: { id: nil }).destroy_all
+    User.left_joins(:user_interventions).where(roles: ['predefined_participant'], user_interventions: { id: nil }).destroy_all
   end
 
   def create_notification!(intervention)

--- a/app/jobs/data_clear_jobs/clear_user_data.rb
+++ b/app/jobs/data_clear_jobs/clear_user_data.rb
@@ -18,8 +18,9 @@ class DataClearJobs::ClearUserData < ApplicationJob
   private
 
   def delete_temporary_users_without_any_intervention!
-    User.left_joins(:user_interventions).where(roles: ['guest'], user_interventions: { id: nil }).destroy_all
-    User.left_joins(:user_interventions).where(roles: ['predefined_participant'], user_interventions: { id: nil }).destroy_all
+    User.left_joins(:user_interventions)
+        .where("CAST(roles AS TEXT[]) && ARRAY['guest', 'predefined_participant'] AND user_interventions.id IS NULL")
+        .destroy_all
   end
 
   def create_notification!(intervention)

--- a/app/models/ability/predefined_participant.rb
+++ b/app/models/ability/predefined_participant.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Ability::PredefinedParticipant < Ability::Base
+  include Ability::Generic::FillInterventionAccess
+
+  def definition
+    super
+    guest if role?(class_name)
+  end
+
+  private
+
+  def guest
+    enable_fill_in_access(user.id, { status: 'published', shared_to: 'anyone' })
+    can %i[index create], LiveChat::Conversation
+  end
+end

--- a/app/models/ability/predefined_participant.rb
+++ b/app/models/ability/predefined_participant.rb
@@ -5,12 +5,12 @@ class Ability::PredefinedParticipant < Ability::Base
 
   def definition
     super
-    guest if role?(class_name)
+    predefined_participant if role?(class_name)
   end
 
   private
 
-  def guest
+  def predefined_participant
     enable_fill_in_access(user.id, { status: 'published', shared_to: 'anyone' })
     can %i[index create], LiveChat::Conversation
   end

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -27,7 +27,7 @@ class Intervention < ApplicationRecord
   has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :live_chat_summoning_users, class_name: 'LiveChat::SummoningUser', dependent: :destroy
   has_many :predefined_user_parameters, dependent: :destroy
-  has_many :predefined_users, through: :predefined_user_parameters, source: :user # , class_name: 'User'
+  has_many :predefined_users, through: :predefined_user_parameters, source: :user
 
   has_many :collaborators, dependent: :destroy, inverse_of: :intervention
   belongs_to :current_editor, class_name: 'User', optional: true

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -27,7 +27,7 @@ class Intervention < ApplicationRecord
   has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :live_chat_summoning_users, class_name: 'LiveChat::SummoningUser', dependent: :destroy
   has_many :predefined_user_parameters, dependent: :destroy
-  has_many :predefined_users, through: :predefined_user_parameters, class_name: 'User'
+  has_many :predefined_users, through: :predefined_user_parameters, source: :user # , class_name: 'User'
 
   has_many :collaborators, dependent: :destroy, inverse_of: :intervention
   belongs_to :current_editor, class_name: 'User', optional: true

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -26,6 +26,8 @@ class Intervention < ApplicationRecord
   has_many :navigators, through: :intervention_navigators, source: :user
   has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :live_chat_summoning_users, class_name: 'LiveChat::SummoningUser', dependent: :destroy
+  has_many :predefined_user_parameters, dependent: :destroy
+  has_many :predefined_users, through: :predefined_user_parameters, class_name: 'User'
 
   has_many :collaborators, dependent: :destroy, inverse_of: :intervention
   belongs_to :current_editor, class_name: 'User', optional: true

--- a/app/models/predefined_user_parameter.rb
+++ b/app/models/predefined_user_parameter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class PredefinedUserParameter < ApplicationRecord
+  belongs_to :user
+  belongs_to :intervention
+  belongs_to :health_clinic, optional: true
+
+  validates :slug, uniqueness: true
+
+  before_validation :generate_slug
+
+  def generate_slug(suggested_slug = nil)
+    suggested_slug ||= SecureRandom.base58(4)
+
+    if PredefinedUserParameter.where(slug: suggested_slug).any?
+      generate_slug(suggested_slug + SecureRandom.base58(2))
+    else
+      self.slug = suggested_slug
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,7 +191,7 @@ class User < ApplicationRecord
   end
 
   def with_invalid_email?
-    roles.include?('guest') || roles.include?('preview_session')
+    roles.include?('guest') || roles.include?('preview_session') || roles.include?('predefined_participant')
   end
 
   def cache_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,6 +119,9 @@ class User < ApplicationRecord
   scope :participants, -> { limit_to_roles('participant') }
   scope :limit_to_active, -> { where(active: true) }
   scope :limit_to_roles, ->(roles) { where('ARRAY[?]::varchar[] && roles', roles) if roles.present? }
+  scope :predefined_participants_in_intervention, lambda { |intervention_id|
+    limit_to_roles('predefined_participant').joins(:predefined_user_parameter).where(predefined_user_parameter: { intervention_id: intervention_id })
+  }
 
   # rubocop:disable Layout/LineLength
   scope :active_users_invited_to_organizations, ->(organization_ids) { left_joins(:organization_invitations).where('organization_invitations.organization_id IN (?) AND organization_invitations.accepted_at IS NOT NULL', organization_ids) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,9 +119,6 @@ class User < ApplicationRecord
   scope :participants, -> { limit_to_roles('participant') }
   scope :limit_to_active, -> { where(active: true) }
   scope :limit_to_roles, ->(roles) { where('ARRAY[?]::varchar[] && roles', roles) if roles.present? }
-  scope :predefined_participants_in_intervention, lambda { |intervention_id|
-    limit_to_roles('predefined_participant').joins(:predefined_user_parameter).where(predefined_user_parameter: { intervention_id: intervention_id })
-  }
 
   # rubocop:disable Layout/LineLength
   scope :active_users_invited_to_organizations, ->(organization_ids) { left_joins(:organization_invitations).where('organization_invitations.organization_id IN (?) AND organization_invitations.accepted_at IS NOT NULL', organization_ids) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
 
   # Order of roles is important because final authorization is the sum of all roles
   APP_ROLES = %w[guest preview_session participant third_party health_clinic_admin health_system_admin
-                 organization_admin researcher e_intervention_admin team_admin admin navigator].freeze
+                 organization_admin researcher e_intervention_admin team_admin admin navigator predefined_participant].freeze
 
   FORMATTING_APP_ROLE_EXCEPTIONS = {
     'e_intervention_admin' => 'E-intervention admin',
@@ -43,6 +43,9 @@ class User < ApplicationRecord
   # PHONE NUMBER
   has_one :phone, dependent: :destroy
   accepts_nested_attributes_for :phone, update_only: true
+
+  # ADDITIONAL PARAMETERS FOR PREDEFINED PARTICIPANTS
+  has_one :predefined_user_parameter, dependent: :destroy
 
   # AVATAR
   has_one_attached :avatar

--- a/app/serializers/v1/predefined_participant_serializer.rb
+++ b/app/serializers/v1/predefined_participant_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class V1::PredefinedParticipantSerializer < V1Serializer
+  attributes :full_name, :first_name, :last_name
+
+  attribute :phone do |object|
+    object.phone.as_json(only: %i[iso prefix number confirmed])
+  end
+
+  attribute :slug do |object|
+    object.predefined_user_parameter.slug
+  end
+
+  attribute :health_clinic_id do |object|
+    object.predefined_user_parameter.health_clinic_id
+  end
+end

--- a/app/services/v1/intervention/predefined_participants/create_service.rb
+++ b/app/services/v1/intervention/predefined_participants/create_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class V1::Intervention::PredefinedParticipants::CreateService
+  def initialize(intervention, params)
+    @intervention = intervention
+    @params = params
+  end
+
+  def self.call(intervention, params)
+    new(intervention, params).call
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      user = create_predefined_user!
+      Phone.create!(phone_params.merge({ user: user })) if phone_params
+      PredefinedUserParameter.create!(user: user, intervention: intervention, health_clinic_id: params[:health_clinic_id])
+      user
+    end
+  end
+
+  private
+
+  attr_reader :params, :intervention
+
+  def phone_params
+    params[:phone_attributes]
+  end
+
+  def create_predefined_user!
+    User.new.tap do |user|
+      user.roles = %w[predefined_participant]
+      user.skip_confirmation!
+      user.email = "#{Time.current.to_i}_#{SecureRandom.hex(10)}@predefined-participant.true"
+      user.first_name = params[:first_name]
+      user.last_name = params[:last_name]
+      user.save(validate: false)
+    end
+  end
+end

--- a/app/services/v1/intervention/predefined_participants/update_service.rb
+++ b/app/services/v1/intervention/predefined_participants/update_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class V1::Intervention::PredefinedParticipants::UpdateService
+  def initialize(intervention, user, params)
+    @intervention = intervention
+    @user = user
+    @params = params
+  end
+
+  def self.call(intervention, user, params)
+    new(intervention, user, params).call
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      user.update!(user_params)
+      user.predefined_user_parameter.update(health_clinic_id: health_clinic_id) if health_clinic_id.present?
+    end
+    user
+  end
+
+  private
+
+  attr_reader :params, :intervention
+  attr_accessor :user
+
+  def user_params
+    params.except(:health_clinic_id)
+  end
+
+  def health_clinic_id
+    @health_clinic_id ||= params[:health_clinic_id]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
       get 'generated_conversations_transcript', on: :member
       delete 'user_data', to: 'interventions#clear_user_data', on: :member
       scope module: 'interventions' do
-        resources :predefined_participants
+        resources :predefined_participants, only: %i[index create update show]
         resources :answers, only: %i[index]
         resources :invitations, only: %i[index create destroy]
         resources :accesses, only: %i[index create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       get 'generated_conversations_transcript', on: :member
       delete 'user_data', to: 'interventions#clear_user_data', on: :member
       scope module: 'interventions' do
+        resources :predefined_participants
         resources :answers, only: %i[index]
         resources :invitations, only: %i[index create destroy]
         resources :accesses, only: %i[index create destroy]

--- a/db/migrate/20230901094411_create_predefined_user_parameters.rb
+++ b/db/migrate/20230901094411_create_predefined_user_parameters.rb
@@ -1,0 +1,11 @@
+class CreatePredefinedUserParameters < ActiveRecord::Migration[6.1]
+  def change
+    create_table :predefined_user_parameters, id: :uuid, default: 'uuid_generate_v4()', null: false do |t|
+      t.string :slug, null: false
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :intervention, null: false, foreign_key: true, type: :uuid
+      t.references :health_clinic, null: true, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_30_041924) do
+ActiveRecord::Schema.define(version: 2023_09_01_094411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -652,6 +652,18 @@ ActiveRecord::Schema.define(version: 2023_08_30_041924) do
     t.index ["user_id"], name: "index_phones_on_user_id"
   end
 
+  create_table "predefined_user_parameters", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string "slug", null: false
+    t.uuid "user_id", null: false
+    t.uuid "intervention_id", null: false
+    t.uuid "health_clinic_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["health_clinic_id"], name: "index_predefined_user_parameters_on_health_clinic_id"
+    t.index ["intervention_id"], name: "index_predefined_user_parameters_on_intervention_id"
+    t.index ["user_id"], name: "index_predefined_user_parameters_on_user_id"
+  end
+
   create_table "question_groups", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "session_id", null: false
     t.string "title", null: false
@@ -1050,6 +1062,9 @@ ActiveRecord::Schema.define(version: 2023_08_30_041924) do
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "phones", "live_chat_navigator_setups", column: "navigator_setup_id"
+  add_foreign_key "predefined_user_parameters", "health_clinics"
+  add_foreign_key "predefined_user_parameters", "interventions"
+  add_foreign_key "predefined_user_parameters", "users"
   add_foreign_key "question_groups", "sessions"
   add_foreign_key "questions", "question_groups"
   add_foreign_key "sessions", "cat_mh_languages"

--- a/spec/factories/interventions.rb
+++ b/spec/factories/interventions.rb
@@ -77,6 +77,14 @@ FactoryBot.define do
     trait :with_pdf_report do
       reports { [FactoryHelpers.upload_file('spec/fixtures/pdf/example_report.pdf', binary: true)] }
     end
+
+    trait :with_predefined_participants do
+      after(:create) do |intervention|
+        create_list(:user, 5, :predefined_participant, :confirmed).each do |user|
+          create(:predefined_user_parameter, intervention: intervention, user: user)
+        end
+      end
+    end
   end
 
   factory :intervention_with_logo, class: Intervention do

--- a/spec/factories/predefined_user_parameters.rb
+++ b/spec/factories/predefined_user_parameters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :predefined_user_parameter do
+    association(:intervention)
+    association(:user)
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,6 +31,13 @@ FactoryBot.define do
       roles { %w[guest] }
     end
 
+    trait :predefined_participant do
+      roles { %w[predefined_participant] }
+      after(:build) do |user|
+        PredefinedUserParameter.create!(user: user, intervention: create(:intervention))
+      end
+    end
+
     trait :participant do
       roles { %w[participant] }
     end
@@ -50,6 +57,12 @@ FactoryBot.define do
           new_team = build(:team, team_admin: team_admin)
           team_admin.admins_teams = [new_team]
         end
+      end
+    end
+
+    trait :with_phone do
+      after(:build) do |user|
+        Phone.create!(user: user, iso: 'PL', prefix: '+48', number: '777888999')
       end
     end
 

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Intervention, type: :model do
     it { should have_many(:conversations) }
     it { should have_many(:notifications) }
     it { should have_many(:collaborators) }
+    it { should have_many(:predefined_user_parameters) }
+    it { should have_many(:predefined_users).through(:predefined_user_parameters) }
     it { should belong_to(:google_language).optional }
     it { should be_valid }
     it { should have_many(:short_links).dependent(:destroy) }

--- a/spec/models/predefined_user_parameter_spec.rb
+++ b/spec/models/predefined_user_parameter_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PredefinedUserParameter, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:intervention) }
+  it { should belong_to(:health_clinic).optional(true) }
+  it { validate_uniqueness_of(:slug) }
+
+  it '#generate_slug' do
+    expect(described_class.create!(user: create(:user), intervention: create(:intervention)).slug).to be_present
+  end
+end

--- a/spec/requests/v1/interventions/predefined_participants/create_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/create_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /v1/interventions/:intervention_id/predefined_participants', type: :request do
+  let(:request) do
+    post v1_intervention_predefined_participants_path(intervention_id: intervention.id), params: params, headers: current_user.create_new_auth_token
+  end
+  let!(:intervention) { create(:intervention, user: researcher) }
+  let(:researcher) { create(:user, :researcher, :confirmed) }
+  let(:current_user) { researcher }
+  let(:params) do
+    {
+      predefined_user: {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name
+      }
+    }
+  end
+
+  it 'return correct status' do
+    request
+    expect(response).to have_http_status(:created)
+  end
+
+  it 'return correct body' do
+    request
+    expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
+  end
+
+  context 'other researcher' do
+    let(:other_researcher) { create(:user, :researcher, :confirmed) }
+    let(:current_user) { other_researcher }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other role' do
+    let(:other_user) { create(:user, :participant, :confirmed) }
+    let(:current_user) { other_user }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/v1/interventions/predefined_participants/create_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/create_spec.rb
@@ -28,23 +28,5 @@ RSpec.describe 'POST /v1/interventions/:intervention_id/predefined_participants'
     expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
   end
 
-  context 'other researcher' do
-    let(:other_researcher) { create(:user, :researcher, :confirmed) }
-    let(:current_user) { other_researcher }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
-  context 'other role' do
-    let(:other_user) { create(:user, :participant, :confirmed) }
-    let(:current_user) { other_user }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
+  it_behaves_like 'users without access'
 end

--- a/spec/requests/v1/interventions/predefined_participants/index_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/index_spec.rb
@@ -25,21 +25,5 @@ RSpec.describe 'GET /v1/interventions/:intervention_id/predefined_participants',
     expect(json_response['data'].first['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
   end
 
-  context 'other researcher' do
-    let(:current_user) { create(:user, :researcher, :confirmed) }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
-  context 'other role' do
-    let(:current_user) { create(:user, :participant, :confirmed) }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
+  it_behaves_like 'users without access'
 end

--- a/spec/requests/v1/interventions/predefined_participants/index_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/index_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /v1/interventions/:intervention_id/predefined_participants', type: :request do
+  let!(:intervention) { create(:intervention, :with_predefined_participants, user: researcher) }
+  let(:researcher) { create(:user, :researcher, :confirmed) }
+  let(:current_user) { researcher }
+  let(:request) do
+    get v1_intervention_predefined_participants_path(intervention_id: intervention.id), headers: current_user.create_new_auth_token
+  end
+
+  it 'return correct status' do
+    request
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'return correct body' do
+    request
+    expect(json_response['data'].size).to eql(intervention.predefined_users.size)
+  end
+
+  it 'the element from array has correct keys' do
+    request
+    expect(json_response['data'].first['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
+  end
+
+  context 'other researcher' do
+    let(:current_user) { create(:user, :researcher, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other role' do
+    let(:current_user) { create(:user, :participant, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/v1/interventions/predefined_participants/show_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/show_spec.rb
@@ -31,21 +31,5 @@ RSpec.describe 'GET /v1/interventions/:intervention_id/predefined_participants/:
     end
   end
 
-  context 'other researcher' do
-    let(:current_user) { create(:user, :researcher, :confirmed) }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
-  context 'other role' do
-    let(:current_user) { create(:user, :participant, :confirmed) }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
+  it_behaves_like 'users without access'
 end

--- a/spec/requests/v1/interventions/predefined_participants/show_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/show_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /v1/interventions/:intervention_id/predefined_participants/:id', type: :request do
+  let!(:intervention) { create(:intervention, :with_predefined_participants, user: researcher) }
+  let(:researcher) { create(:user, :researcher, :confirmed) }
+  let(:user) { intervention.predefined_users.first }
+  let(:user_id) { user.id }
+  let(:current_user) { researcher }
+  let(:request) do
+    get v1_intervention_predefined_participant_path(intervention_id: intervention.id, id: user_id), headers: current_user.create_new_auth_token
+  end
+
+  it 'return correct status' do
+    request
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'return correct body' do
+    request
+    expect(json_response['data']['id']).to eql(user.id)
+  end
+
+  context 'when id is wrong' do
+    let(:user_id) { 'wrongId' }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other researcher' do
+    let(:current_user) { create(:user, :researcher, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other role' do
+    let(:current_user) { create(:user, :participant, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/v1/interventions/predefined_participants/update_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/update_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'PATCH /v1/interventions/:intervention_id/predefined_participants/:id', type: :request do
+  let(:request) do
+    patch v1_intervention_predefined_participant_path(intervention_id: intervention.id, id: user.id), params: params, headers: current_user.create_new_auth_token
+  end
+  let!(:intervention) { create(:intervention, user: researcher) }
+  let(:researcher) { create(:user, :researcher, :confirmed) }
+  let(:current_user) { researcher }
+  let(:user) { create(:user, :predefined_participant, :with_phone) }
+  let(:params) do
+    {
+      predefined_user: {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name
+      }
+    }
+  end
+
+  it 'return correct status' do
+    request
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'return correct body' do
+    request
+    require 'pry'; binding.pry
+    expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
+  end
+
+  context 'other researcher' do
+    let(:other_researcher) { create(:user, :researcher, :confirmed) }
+    let(:current_user) { other_researcher }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other role' do
+    let(:other_user) { create(:user, :participant, :confirmed) }
+    let(:current_user) { other_user }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/v1/interventions/predefined_participants/update_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/update_spec.rb
@@ -34,25 +34,7 @@ RSpec.describe 'PATCH /v1/interventions/:intervention_id/predefined_participants
     expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id])
   end
 
-  context 'other researcher' do
-    let(:other_researcher) { create(:user, :researcher, :confirmed) }
-    let(:current_user) { other_researcher }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:not_found)
-    end
-  end
-
-  context 'other role' do
-    let(:other_user) { create(:user, :participant, :confirmed) }
-    let(:current_user) { other_user }
-
-    it 'return correct status' do
-      request
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
+  it_behaves_like 'users without access'
 
   context 'when intervention has collaborators' do
     let!(:intervention) { create(:intervention, :with_collaborators, user: researcher) }

--- a/spec/services/v1/intervention/predefined_participants/create_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/create_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe V1::Intervention::PredefinedParticipants::CreateService do
+  let(:subject) { described_class.call(intervention, params) }
+  let!(:intervention) { create(:intervention) }
+  let!(:health_clinic_id) { create(:health_clinic).id }
+  let(:params) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      health_clinic_id: health_clinic_id,
+      phone_attributes: {
+        iso: 'PL',
+        prefix: '+48',
+        number: '777888999'
+      }
+    }
+  end
+
+  it 'service return a created user' do
+    expect(subject.instance_of?(User)).to be true
+  end
+
+  it 'create a predefined user' do
+    expect { subject }.to change(User, :count).by(1)
+  end
+
+  it 'create a phone' do
+    expect { subject }.to change(Phone, :count).by(1)
+  end
+
+  it 'create a predefined participant params' do
+    expect { subject }.to change(PredefinedUserParameter, :count).by(1)
+  end
+
+  it 'returned user has correct parameters' do
+    expect(subject.slice(:first_name, :last_name,
+                         :roles).deep_transform_keys!(&:to_s)).to include({ first_name: params[:first_name], last_name: params[:last_name],
+                                                                            roles: ['predefined_participant'] })
+  end
+
+  it 'user has assigned phone' do
+    expect(subject.phone).to be_present
+  end
+
+  it 'user has predefined user parameter' do
+    expect(subject.predefined_user_parameter).to be_present
+  end
+
+  context 'when phone_attributes are skipped' do
+    let(:params) do
+      {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        health_clinic_id: health_clinic_id
+      }
+    end
+
+    it 'doesn\'t create a phone' do
+      expect { subject }.not_to change(Phone, :count)
+    end
+  end
+end

--- a/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe V1::Intervention::PredefinedParticipants::UpdateService do
+  let(:subject) { described_class.call(intervention, predefined_participant, params) }
+  let!(:intervention) { create(:intervention) }
+  let!(:health_clinic_id) { create(:health_clinic).id }
+  let(:predefined_participant) { create(:user, :predefined_participant, :with_phone, predefined_user_parameter: PredefinedUserParameter.new(intervention: intervention)) }
+  let(:params) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      health_clinic_id: health_clinic_id,
+      phone_attributes: {
+        number: '878987384'
+      }
+    }
+  end
+
+  it 'service return a created user' do
+    expect(subject.instance_of?(User)).to be true
+  end
+
+  it 'change the user attributes' do
+    expect(subject.slice(:first_name, :last_name)).to include(params.except(:health_clinic_id, :phone_attributes))
+  end
+
+  it 'change the phone number' do
+    expect(subject.phone.number).to eql(params[:phone_attributes][:number])
+  end
+
+  it 'change clinic id' do
+    expect(subject.predefined_user_parameter.health_clinic_id).to eql health_clinic_id
+  end
+end

--- a/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe V1::Intervention::PredefinedParticipants::UpdateService do
   let(:subject) { described_class.call(intervention, predefined_participant, params) }
   let!(:intervention) { create(:intervention) }
   let!(:health_clinic_id) { create(:health_clinic).id }
-  let(:predefined_participant) { create(:user, :predefined_participant, :with_phone, predefined_user_parameter: PredefinedUserParameter.new(intervention: intervention)) }
+  let(:predefined_participant) do
+    create(:user, :predefined_participant, :with_phone, predefined_user_parameter: PredefinedUserParameter.new(intervention: intervention))
+  end
   let(:params) do
     {
       first_name: Faker::Name.first_name,

--- a/spec/support/shared_examples/predefined_participants/users_without_access.rb
+++ b/spec/support/shared_examples/predefined_participants/users_without_access.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'users without access' do
+  context 'other researcher' do
+    let(:current_user) { create(:user, :researcher, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'other role' do
+    let(:current_user) { create(:user, :participant, :confirmed) }
+
+    it 'return correct status' do
+      request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
## Related tasks
- [CIAS-3636](https://htdevelopers.atlassian.net/browse/CIAS30-3636)

## What's new?
- Predefined participants will now be cleared alongside their `PredefinedUserParameter` when clearing data for an intervention
