### PR TITLE
[CIAS30-3671] Return health_clinic_id when fetching user intervention

### DIFF
--- a/app/serializers/v1/user_intervention_serializer.rb
+++ b/app/serializers/v1/user_intervention_serializer.rb
@@ -2,7 +2,7 @@
 
 class V1::UserInterventionSerializer < V1Serializer
   include FileHelper
-  attributes :completed_sessions, :status, :last_answer_date, :contain_multiple_fill_session
+  attributes :completed_sessions, :status, :last_answer_date, :contain_multiple_fill_session, :health_clinic_id
 
   attribute :sessions_in_intervention do |object|
     object.sessions.size

--- a/spec/requests/v1/user_interventions/index_spec.rb
+++ b/spec/requests/v1/user_interventions/index_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'GET /v1/user_interventions', type: :request do
             'sessions_in_intervention' => 5,
             'last_answer_date' => nil,
             'contain_multiple_fill_session' => false,
+            'health_clinic_id' => nil,
             'intervention' => {
               'id' => intervention.id,
               'type' => intervention.type,
@@ -62,6 +63,7 @@ RSpec.describe 'GET /v1/user_interventions', type: :request do
             'sessions_in_intervention' => 5,
             'last_answer_date' => nil,
             'contain_multiple_fill_session' => false,
+            'health_clinic_id' => nil,
             'intervention' => {
               'id' => intervention.id,
               'type' => intervention.type,
@@ -84,6 +86,7 @@ RSpec.describe 'GET /v1/user_interventions', type: :request do
             'sessions_in_intervention' => 5,
             'last_answer_date' => nil,
             'contain_multiple_fill_session' => false,
+            'health_clinic_id' => nil,
             'intervention' => {
               'id' => intervention.id,
               'type' => intervention.type,
@@ -106,6 +109,7 @@ RSpec.describe 'GET /v1/user_interventions', type: :request do
             'sessions_in_intervention' => 5,
             'last_answer_date' => nil,
             'contain_multiple_fill_session' => false,
+            'health_clinic_id' => nil,
             'intervention' => {
               'id' => intervention.id,
               'type' => intervention.type,

--- a/spec/requests/v1/user_interventions/show_spec.rb
+++ b/spec/requests/v1/user_interventions/show_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe 'GET /v1/user_interventions/:id', type: :request do
   let!(:user) { create(:user, :admin, :confirmed) }
   let!(:intervention) { create(:flexible_order_intervention, user: user, status: 'published', shared_to: 'registered') }
   let!(:sessions) { create_list(:session, 3, intervention_id: intervention.id) }
-  let!(:user_intervention) { create(:user_intervention, intervention_id: intervention.id, user: user) }
+  let!(:health_clinic) { create(:health_clinic) }
+  let!(:user_intervention) { create(:user_intervention, intervention_id: intervention.id, user: user, health_clinic_id: health_clinic.id) }
 
   let(:request) { get v1_user_intervention_path(user_intervention.id), headers: user.create_new_auth_token }
 
@@ -29,6 +30,10 @@ RSpec.describe 'GET /v1/user_interventions/:id', type: :request do
 
     it 'returns correct intervention type' do
       expect(json_response['data']['attributes']['intervention']['type']).to eq intervention.type
+    end
+
+    it 'returns correct health clinic id' do
+      expect(json_response['data']['attributes']['health_clinic_id']).to eq health_clinic.id
     end
   end
 


### PR DESCRIPTION
## Related tasks
- [CIAS-3671](https://htdevelopers.atlassian.net/browse/CIAS30-3671)

## What's new?
- Fetching a user intervention will now return a body with a field `health_clinic_id` under `attributes`
