### PR TITLE
[CIAS30-3672] Don't allow creating user session without health_clinic_id in interventions inside organization

### DIFF
--- a/app/models/user_intervention.rb
+++ b/app/models/user_intervention.rb
@@ -25,8 +25,6 @@ class UserIntervention < ApplicationRecord
   end
 
   def intervention_inside_organization?
-    return false if intervention.nil?
-
-    intervention.organization_id.present?
+    intervention&.organization_id.present?
   end
 end

--- a/app/models/user_intervention.rb
+++ b/app/models/user_intervention.rb
@@ -8,6 +8,8 @@ class UserIntervention < ApplicationRecord
 
   delegate :sessions, to: :intervention
 
+  validates :health_clinic_id, presence: true, if: :intervention_inside_organization?
+
   enum status: { ready_to_start: 'ready_to_start', in_progress: 'in_progress', completed: 'completed', schedule_pending: 'schedule_pending' }
 
   def last_answer_date
@@ -20,5 +22,11 @@ class UserIntervention < ApplicationRecord
 
   def contain_multiple_fill_session
     sessions.multiple_fill.any?
+  end
+
+  def intervention_inside_organization?
+    return false if intervention.nil?
+
+    intervention.organization_id.present?
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -10,6 +10,8 @@ class UserSession < ApplicationRecord
   has_many :tlfb_days, class_name: 'Tlfb::Day', dependent: :destroy
   belongs_to :health_clinic, optional: true
 
+  validate :correct_health_clinic_id?
+
   def finish(_send_email: true)
     raise NotImplementedError, "subclass did not define #{__method__}"
   end
@@ -69,5 +71,9 @@ class UserSession < ApplicationRecord
     return session.last_session? && finished_at.present? unless user_intervention.intervention.module_intervention?
 
     user_intervention.completed_sessions == user_intervention.sessions.size
+  end
+
+  def correct_health_clinic_id?
+    user_intervention.intervention.health_clinic_id == health_clinic_id
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -74,6 +74,6 @@ class UserSession < ApplicationRecord
   end
 
   def correct_health_clinic_id?
-    user_intervention.intervention.health_clinic_id == health_clinic_id
+    user_intervention.intervention.organization.blank? == health_clinic_id.blank?
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -10,7 +10,7 @@ class UserSession < ApplicationRecord
   has_many :tlfb_days, class_name: 'Tlfb::Day', dependent: :destroy
   belongs_to :health_clinic, optional: true
 
-  validates :health_clinic_id, presence: true, if: :intervention_inside_organization?
+  validates :health_clinic_id, presence: true, if: :user_intervention_inside_health_clinic?
 
   def finish(_send_email: true)
     raise NotImplementedError, "subclass did not define #{__method__}"
@@ -73,7 +73,9 @@ class UserSession < ApplicationRecord
     user_intervention.completed_sessions == user_intervention.sessions.size
   end
 
-  def intervention_inside_organization?
-    user_intervention&.intervention&.organization_id.present?
+  def user_intervention_inside_health_clinic?
+    return false if user_intervention.nil?
+
+    user_intervention.health_clinic_id.present?
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -10,7 +10,7 @@ class UserSession < ApplicationRecord
   has_many :tlfb_days, class_name: 'Tlfb::Day', dependent: :destroy
   belongs_to :health_clinic, optional: true
 
-  validate :correct_health_clinic_id?
+  validates :health_clinic_id, presence: true, if: :intervention_inside_organization?
 
   def finish(_send_email: true)
     raise NotImplementedError, "subclass did not define #{__method__}"
@@ -73,7 +73,7 @@ class UserSession < ApplicationRecord
     user_intervention.completed_sessions == user_intervention.sessions.size
   end
 
-  def correct_health_clinic_id?
-    user_intervention.intervention.organization_id.blank? == health_clinic_id.blank?
+  def intervention_inside_organization?
+    user_intervention&.intervention&.organization_id.present?
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -74,8 +74,6 @@ class UserSession < ApplicationRecord
   end
 
   def user_intervention_inside_health_clinic?
-    return false if user_intervention.nil?
-
-    user_intervention.health_clinic_id.present?
+    user_intervention&.health_clinic_id.present?
   end
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -74,6 +74,6 @@ class UserSession < ApplicationRecord
   end
 
   def correct_health_clinic_id?
-    user_intervention.intervention.organization.blank? == health_clinic_id.blank?
+    user_intervention.intervention.organization_id.blank? == health_clinic_id.blank?
   end
 end

--- a/spec/models/user_intervention_spec.rb
+++ b/spec/models/user_intervention_spec.rb
@@ -9,5 +9,28 @@ RSpec.describe UserIntervention, type: :model do
     it { should belong_to(:user) }
     it { should belong_to(:intervention) }
     it { should have_many(:user_sessions) }
+
+    context 'validation' do
+      let(:intervention) { create(:intervention, organization: organization) }
+
+      context 'when in an intervention in an organization' do
+        let(:organization) { create(:organization, :with_health_clinics) }
+        let(:health_clinic) { organization.health_clinics.sample }
+        let!(:user_intervention) { create(:user_intervention, intervention: intervention, health_clinic_id: health_clinic.id) }
+
+        it 'disallows for health_clinic_id to be nil' do
+          expect { user_intervention.update!(health_clinic_id: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context 'when in an intervention not in an organization' do
+        let(:organization) { nil }
+        let!(:user_intervention) { create(:user_intervention, intervention: intervention) }
+
+        it 'allows for health_clinic_id to be nil' do
+          expect(user_intervention.update!(health_clinic_id: nil)).to eq true
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe UserSession, type: :model do
             expect(answers.size).to be(2)
             variables = [answers.first.decrypted_body, answers.last.decrypted_body]
             expect(variables).to include(
-                                   { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
-                                   { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
-                                 )
+              { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
+              { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
+            )
           end
         end
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -211,19 +211,21 @@ RSpec.describe UserSession, type: :model do
   context 'validation' do
     let(:intervention) { create(:intervention, organization: organization) }
     let!(:sessions) { create_list(:session, 2, intervention: intervention) }
-    let!(:user_intervention) { create(:user_intervention, intervention: intervention, status: 'in_progress', completed_sessions: 1) }
 
-    context 'when in an intervention in an organization' do
+    context 'when in an user intervention with a health clinic' do
       let(:organization) { create(:organization, :with_health_clinics) }
-      let!(:user_session) { create(:user_session, user_intervention: user_intervention, health_clinic: organization.health_clinics.sample) }
+      let(:health_clinic) { organization.health_clinics.sample }
+      let!(:user_intervention) { create(:user_intervention, intervention: intervention, health_clinic_id: health_clinic.id) }
+      let!(:user_session) { create(:user_session, user_intervention: user_intervention, health_clinic_id: health_clinic.id) }
 
       it 'disallows for health_clinic_id to be nil' do
         expect { user_session.update!(health_clinic_id: nil) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
-    context 'when in an intervention without an organization' do
+    context 'when in an user intervention without a health clinic' do
       let(:organization) { nil }
+      let!(:user_intervention) { create(:user_intervention, intervention: intervention) }
       let!(:user_session) { create(:user_session, user_intervention: user_intervention) }
 
       it 'allows for health_clinic_id to be nil' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3672](https://htdevelopers.atlassian.net/browse/CIAS30-3672)

## What's new?
- 
