### PR TITLE
[CIAS30-3660] fix "Duplicate Here" option for invited collaborator making copy to a intervention owner

### DIFF
--- a/app/jobs/clone_jobs/intervention.rb
+++ b/app/jobs/clone_jobs/intervention.rb
@@ -4,6 +4,8 @@ class CloneJobs::Intervention < CloneJob
   def perform(user, intervention_id, clone_params)
     intervention = Intervention.find(intervention_id)
 
+    clone_params['user_id'] = user.id
+
     cloned_interventions = intervention.clone(params: clone_params)
     cloned_interventions = Array(cloned_interventions) unless cloned_interventions.is_a?(Array)
 

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -10,12 +10,9 @@ module Clone
 
     if emails.blank?
       if user_id.present?
-        return "Clone::#{de_constantize_modulize_name.classify}".
-          safe_constantize.new(self, user_id: user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
-      else
-        return "Clone::#{de_constantize_modulize_name.classify}".
-          safe_constantize.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+        return clone_module.new(self, user_id: user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
       end
+      return clone_module.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
     end
 
     cloned_elements = []
@@ -28,12 +25,17 @@ module Clone
     user_ids.each do |user_id|
       cloned_elements
         .push(
-          "Clone::#{de_constantize_modulize_name.classify}".
-            safe_constantize.
+          clone_module.
             new(self, { user_id: user_id, clean_formulas: clean_formulas, position: position, hidden: hidden }).
             execute
         )
     end
     cloned_elements
+  end
+
+  private
+
+  def clone_module
+    "Clone::#{de_constantize_modulize_name.classify}".safe_constantize
   end
 end

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -9,11 +9,7 @@ module Clone
     current_user_id = params[:user_id]
 
     if emails.blank?
-      if current_user_id.present?
-        return clone_module.new(self, user_id: current_user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
-      end
-
-      return clone_module.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+      return clone_module.new(self, user_id: current_user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
     end
 
     cloned_elements = []

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -9,7 +9,7 @@ module Clone
     current_user_id = params[:user_id]
 
     if emails.blank?
-      if user_id.present?
+      if current_user_id.present?
         return clone_module.new(self, user_id: current_user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
       end
 

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -12,6 +12,7 @@ module Clone
       if user_id.present?
         return clone_module.new(self, user_id: user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
       end
+
       return clone_module.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
     end
 
@@ -23,12 +24,9 @@ module Clone
     user_ids = User.where(email: emails).limit_to_roles(%w[e_intervention_admin researcher]).pluck(:id)
 
     user_ids.each do |user_id|
-      cloned_elements
-        .push(
-          clone_module.
-            new(self, { user_id: user_id, clean_formulas: clean_formulas, position: position, hidden: hidden }).
-            execute
-        )
+      cloned_elements.push(
+        clone_module.new(self, { user_id: user_id, clean_formulas: clean_formulas, position: position, hidden: hidden }).execute
+      )
     end
     cloned_elements
   end

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -6,10 +6,16 @@ module Clone
 
   def clone(params: {}, clean_formulas: true, position: nil, hidden: false)
     emails = params[:emails]&.map(&:downcase)
+    user_id = params[:user_id]
 
     if emails.blank?
-      return "Clone::#{de_constantize_modulize_name.classify}".
-        safe_constantize.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+      if user_id.present?
+        return "Clone::#{de_constantize_modulize_name.classify}".
+          safe_constantize.new(self, user_id: user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+      else
+        return "Clone::#{de_constantize_modulize_name.classify}".
+          safe_constantize.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+      end
     end
 
     cloned_elements = []

--- a/app/models/concerns/clone.rb
+++ b/app/models/concerns/clone.rb
@@ -6,11 +6,11 @@ module Clone
 
   def clone(params: {}, clean_formulas: true, position: nil, hidden: false)
     emails = params[:emails]&.map(&:downcase)
-    user_id = params[:user_id]
+    current_user_id = params[:user_id]
 
     if emails.blank?
       if user_id.present?
-        return clone_module.new(self, user_id: user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
+        return clone_module.new(self, user_id: current_user_id, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
       end
 
       return clone_module.new(self, clean_formulas: clean_formulas, position: position, params: params, hidden: hidden).execute
@@ -33,6 +33,7 @@ module Clone
 
   private
 
+  # returns the corresponding clone module (e.g. Intervention -> Clone::Intervention)
   def clone_module
     "Clone::#{de_constantize_modulize_name.classify}".safe_constantize
   end

--- a/app/models/concerns/clone/base.rb
+++ b/app/models/concerns/clone/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Clone::Base
-  attr_accessor :source, :outcome, :options, :hidden, :clean_formulas, :position, :session_variables
+  attr_accessor :source, :outcome, :options, :hidden, :clean_formulas, :position, :user_id, :session_variables
 
   def initialize(source, **options)
     @source = source
@@ -10,6 +10,7 @@ class Clone::Base
     @clean_formulas = options.delete(:clean_formulas)
     @hidden = options.delete(:hidden)
     @position = options.delete(:position)
+    @user_id = options.delete(:user_id)
     @outcome.variable = options[:params][:variable] if options[:params].present? && options[:params][:variable].present?
     options.delete(:params)
     @outcome.assign_attributes(options)

--- a/app/models/concerns/clone/intervention.rb
+++ b/app/models/concerns/clone/intervention.rb
@@ -6,6 +6,7 @@ class Clone::Intervention < Clone::Base
     outcome.sensitive_data_state = 'collected'
     outcome.name = "Copy of #{outcome.name}"
     outcome.is_hidden = true
+    outcome.user_id = user_id if user_id.present?
     clear_organization!
     clear_cat_mh_settings!
     clear_hfhs_settings!

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -262,5 +262,16 @@ RSpec.describe Intervention, type: :model do
         expect(cloned_intervention.first.user_id).to eq(other_user.id)
       end
     end
+
+    context 'when the user duplicates here a session of another user' do
+      let(:other_user) { create(:user, :confirmed, :researcher) }
+      let(:params) { { user_id: other_user.id } }
+
+      it 'create a new intervention with correct user_id' do
+        cloned_intervention = intervention.clone(params: params)
+
+        expect(cloned_intervention.user).to eq(other_user)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3660](https://htdevelopers.atlassian.net/browse/CIAS30-3660)

## What's new?
- Using "Duplicate here" will now clone the intervention and make the user who requested the clone the owner, instead of the owner being always the owner of the original one
