### PR TITLE
[CIAS30-3639] skip participant report screen for predefined participants

### DIFF
--- a/spec/services/v1/flow_service/next_question_spec.rb
+++ b/spec/services/v1/flow_service/next_question_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe V1::FlowService::NextQuestion do
+  subject { described_class.new(user_session).call(nil) }
+
+  let(:predefined_user) { create(:user, :predefined_participant) }
+  let(:intervention) { create(:intervention, status: :published) }
+  let!(:session) { create(:session, intervention_id: intervention.id) }
+  let(:user_int) { create(:user_intervention, intervention: intervention, user: predefined_user) }
+  let!(:user_session) { create(:user_session, user_id: predefined_user.id, session_id: session.id, user_intervention: user_int) }
+  let!(:question_group) { create(:question_group, session: session, position: 1) }
+  let!(:question) { create(:question_participant_report, question_group: question_group, position: 1) }
+
+  it 'first and last question is participant report screen' do
+    expect(subject.type).to eql('Question::Finish')
+  end
+
+  context 'question group has next question' do
+    let!(:single_question) { create(:question_single, question_group: question_group, position: 2) }
+
+    it 'returns FinishQuestion' do
+      expect(subject.id).to eql(single_question.id)
+    end
+  end
+
+  context 'user has some answers' do
+    let!(:question) { create(:question_single, question_group: question_group, position: 1) }
+    let!(:answer) { create(:answer_single, question_id: question.id, user_session_id: user_session.id) }
+    let!(:second_question) { create(:question_participant_report, question_group: question_group, position: 2) }
+
+    it 'first and last question is participant report screen' do
+      expect(subject.type).to eql('Question::Finish')
+    end
+
+    context 'single question after participnat report screen' do
+      let!(:single_question) { create(:question_single, question_group: question_group, position: 3) }
+
+      it 'returns next single question' do
+        expect(subject.id).to eql(single_question.id)
+      end
+    end
+
+    context 'question from next question group' do
+      let!(:second_question_group) { create(:question_group, session: session, position: 2) }
+      let!(:first_question_in_next_group) { create(:question_single, question_group: second_question_group) }
+
+      it 'returns the first question from the next question group' do
+        expect(subject.id).to eql(first_question_in_next_group.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related tasks
- [CIAS-3639](https://htdevelopers.atlassian.net/browse/CIAS30-3639)

## What's new?
- detect if a user is a predefined user and skip the participant report's screen 
