### PR TITLE
[CIAS30-3665] fix the possibility to invite a user with an incorrect email address

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -263,6 +263,14 @@ class User < ApplicationRecord
     first_name.blank? || last_name.blank? || !terms
   end
 
+  def self.invite!(attributes = {}, invited_by = nil, options = {}, &block)
+    User.new(**attributes).tap do |user|
+      user.valid?
+      raise ActiveRecord::RecordInvalid if user.errors[:email].present?
+    end
+    super(attributes, invited_by, options, &block)
+  end
+
   private
 
   def send_welcome_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   # TEAMS
   belongs_to :team, optional: true # for members of team
   has_many :admins_teams, class_name: 'Team', dependent: :nullify,
-           foreign_key: :team_admin_id, inverse_of: :team_admin # for team admin
+                          foreign_key: :team_admin_id, inverse_of: :team_admin # for team admin
   delegate :name, to: :team, prefix: true, allow_nil: true
 
   # ORGANIZATIONS
@@ -77,7 +77,7 @@ class User < ApplicationRecord
 
   # REPORTS AVAILABLE FOR THIRD PARTY USER
   has_many :generated_reports_third_party_users, foreign_key: :third_party_id, inverse_of: :third_party,
-           dependent: :destroy
+                                                 dependent: :destroy
 
   # DOWNLOADED REPORTS
   has_many :downloaded_reports, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   # TEAMS
   belongs_to :team, optional: true # for members of team
   has_many :admins_teams, class_name: 'Team', dependent: :nullify,
-                          foreign_key: :team_admin_id, inverse_of: :team_admin # for team admin
+           foreign_key: :team_admin_id, inverse_of: :team_admin # for team admin
   delegate :name, to: :team, prefix: true, allow_nil: true
 
   # ORGANIZATIONS
@@ -77,7 +77,7 @@ class User < ApplicationRecord
 
   # REPORTS AVAILABLE FOR THIRD PARTY USER
   has_many :generated_reports_third_party_users, foreign_key: :third_party_id, inverse_of: :third_party,
-                                                 dependent: :destroy
+           dependent: :destroy
 
   # DOWNLOADED REPORTS
   has_many :downloaded_reports, dependent: :destroy
@@ -264,10 +264,8 @@ class User < ApplicationRecord
   end
 
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &block)
-    User.new(**attributes).tap do |user|
-      user.valid?
-      raise ActiveRecord::RecordInvalid if user.errors[:email].present?
-    end
+    return if User.new(**attributes).tap(&:valid?).errors[:email].present?
+
     super(attributes, invited_by, options, &block)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,7 +264,8 @@ class User < ApplicationRecord
   end
 
   def self.invite!(attributes = {}, invited_by = nil, options = {}, &block)
-    return if User.new(**attributes).tap(&:valid?).errors[:email].present?
+    user = User.new(**attributes)
+    return user if user.tap(&:valid?).errors.messages_for(:email).include? 'is not an email'
 
     super(attributes, invited_by, options, &block)
   end

--- a/spec/requests/v1/users/invitations/create_spec.rb
+++ b/spec/requests/v1/users/invitations/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'POST /v1/users/invitations', type: :request do
   let(:request) { post v1_invitations_path, params: params, headers: headers }
-  let(:params)  do
+  let(:params) do
     {
       invitation: {
         email: 'test@example.com',
@@ -34,7 +34,7 @@ describe 'POST /v1/users/invitations', type: :request do
 
   context 'when authenticated as admin user' do
     let(:admin_user) { create(:user, :admin) }
-    let(:headers)    { admin_user.create_new_auth_token }
+    let(:headers) { admin_user.create_new_auth_token }
 
     context 'when valid params provided' do
       before do
@@ -85,7 +85,7 @@ describe 'POST /v1/users/invitations', type: :request do
       end
 
       it 'returns correct error message' do
-        expect(json_response['error']).to eq 'Email is not an email and Terms must be accepted'
+        expect(json_response['error']).to include('Email is not an email', 'Terms must be accepted')
       end
     end
   end

--- a/spec/services/v1/users/invitations/create_spec.rb
+++ b/spec/services/v1/users/invitations/create_spec.rb
@@ -33,8 +33,16 @@ RSpec.describe V1::Users::Invitations::Create do
     end
   end
 
-  context 'email is invalid' do
+  context 'email is nil' do
     let(:email) { nil }
+
+    it 'does not create new user' do
+      expect { subject }.not_to change(User, :count)
+    end
+  end
+
+  context 'email is invalid' do
+    let(:email) { 'a@a.a' }
 
     it 'does not create new user' do
       expect { subject }.not_to change(User, :count)


### PR DESCRIPTION
## Related tasks
- [CIAS-3665](https://htdevelopers.atlassian.net/browse/CIAS30-3665)

## What's new?
- `User.invite!` was overridden to check for the correctness of the email address
