### PR TITLE
[CIAS30-3689] mark all answers for the question as draft

### DIFF
--- a/app/services/v1/user_sessions/previous_question_service.rb
+++ b/app/services/v1/user_sessions/previous_question_service.rb
@@ -18,7 +18,7 @@ class V1::UserSessions::PreviousQuestionService
     raise CatMh::ActionNotAvailable, I18n.t('user_sessions.errors.previous_question') if user_session.type == 'UserSession::CatMh'
 
     @previous_answer = user_session.answers.where('created_at < ? AND draft = false', (answer&.created_at || DateTime.now))&.last
-    previous_answer&.update!(draft: true)
+    Answer.where(question_id: previous_answer.question_id, user_session_id: user_session.id).update_all(draft: true) if previous_answer.present? # rubocop:disable Rails/SkipsModelValidations
 
     {
       question: previous_question,

--- a/spec/requests/v1/user_sessions/questions/previous_spec.rb
+++ b/spec/requests/v1/user_sessions/questions/previous_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe 'GET /v1/user_sessions/:user_session_id/previous_question', type:
         request
         expect(json_response.keys).to match_array(%w[data answer])
       end
+
+      context 'when user has two answers for the same question' do
+        let!(:answer2) { create(:answer_single, question: question1, user_session: user_session, created_at: 2.days.ago) }
+
+        it 'return correct question id' do
+          request
+          expect(json_response['data']['id']).to eq(question1.id)
+        end
+
+        it 'mark both answers as draft' do
+          request
+          expect(answer.reload.draft).to be true
+          expect(answer2.reload.draft).to be true
+        end
+      end
     end
 
     context 'when user want to see last question -  second undo' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3689](https://htdevelopers.atlassian.net/browse/CIAS30-3689)

## What's new?
- when using the back button, we mark all answers as draft assigned to this question, instead of the last one
