### PR TITLE
[CIAS30-3730] fix researcher cannot open preview when intervention belongs to the organiation

### DIFF
--- a/app/models/user_intervention.rb
+++ b/app/models/user_intervention.rb
@@ -8,7 +8,7 @@ class UserIntervention < ApplicationRecord
 
   delegate :sessions, to: :intervention
 
-  validates :health_clinic_id, presence: true, if: :intervention_inside_organization?
+  validates :health_clinic_id, presence: true, if: -> { intervention_inside_organization? && !preview? }
 
   enum status: { ready_to_start: 'ready_to_start', in_progress: 'in_progress', completed: 'completed', schedule_pending: 'schedule_pending' }
 
@@ -22,6 +22,10 @@ class UserIntervention < ApplicationRecord
 
   def contain_multiple_fill_session
     sessions.multiple_fill.any?
+  end
+
+  def preview?
+    user.role?('preview_session')
   end
 
   def intervention_inside_organization?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -10,7 +10,7 @@ class UserSession < ApplicationRecord
   has_many :tlfb_days, class_name: 'Tlfb::Day', dependent: :destroy
   belongs_to :health_clinic, optional: true
 
-  validates :health_clinic_id, presence: true, if: :user_intervention_inside_health_clinic?
+  validates :health_clinic_id, presence: true, if: -> { user_intervention_inside_health_clinic? && !preview? }
 
   def finish(_send_email: true)
     raise NotImplementedError, "subclass did not define #{__method__}"
@@ -71,6 +71,10 @@ class UserSession < ApplicationRecord
     return session.last_session? && finished_at.present? unless user_intervention.intervention.module_intervention?
 
     user_intervention.completed_sessions == user_intervention.sessions.size
+  end
+
+  def preview?
+    user.role?('preview_session')
   end
 
   def user_intervention_inside_health_clinic?

--- a/spec/models/user_intervention_spec.rb
+++ b/spec/models/user_intervention_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe UserIntervention, type: :model do
         it 'disallows for health_clinic_id to be nil' do
           expect { user_intervention.update!(health_clinic_id: nil) }.to raise_error(ActiveRecord::RecordInvalid)
         end
+
+        context 'when preview' do
+          let(:preview_user) { create(:user, :preview_session) }
+          let!(:user_intervention) { create(:user_intervention, user: preview_user, intervention: intervention, health_clinic_id: health_clinic.id) }
+
+          it 'allows for health_clinic_id to be nil' do
+            expect(user_intervention.update!(health_clinic_id: nil)).to eq true
+          end
+        end
       end
 
       context 'when in an intervention not in an organization' do

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe UserSession, type: :model do
             expect(answers.size).to be(2)
             variables = [answers.first.decrypted_body, answers.last.decrypted_body]
             expect(variables).to include(
-                                   { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
-                                   { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
-                                 )
+              { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
+              { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
+            )
           end
         end
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe UserSession, type: :model do
             expect(answers.size).to be(2)
             variables = [answers.first.decrypted_body, answers.last.decrypted_body]
             expect(variables).to include(
-              { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
-              { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
-            )
+                                   { 'data' => [{ 'var' => 'dep_severity', 'value' => 43.9 }] },
+                                   { 'data' => [{ 'var' => 'dep_precision', 'value' => 5.0 }] }
+                                 )
           end
         end
 
@@ -220,6 +220,16 @@ RSpec.describe UserSession, type: :model do
 
       it 'disallows for health_clinic_id to be nil' do
         expect { user_session.update!(health_clinic_id: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      context 'when preview' do
+        let(:preview_user) { create(:user, :preview_session) }
+        let!(:user_intervention) { create(:user_intervention, user: preview_user, intervention: intervention, health_clinic_id: health_clinic.id) }
+        let!(:user_session) { create(:user_session, user: preview_user, user_intervention: user_intervention, health_clinic_id: health_clinic.id) }
+
+        it 'allows for health_clinic_id to be nil' do
+          expect(user_session.update!(health_clinic_id: nil)).to eq true
+        end
       end
     end
 


### PR DESCRIPTION
## Related tasks
- [CIAS-3730](https://htdevelopers.atlassian.net/browse/CIAS30-3730)

## What's new?
- If a user session or a user intervention is inside an organization, but belongs to a preview user the health clinic validation won't be triggered
