### PR TITLE
[CIAS30-3733] add missing attributes to serializer

### DIFF
--- a/app/serializers/v1/predefined_participant_serializer.rb
+++ b/app/serializers/v1/predefined_participant_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class V1::PredefinedParticipantSerializer < V1Serializer
-  attributes :full_name, :first_name, :last_name, :email
+  attributes :full_name, :first_name, :last_name, :email, :active
 
   attribute :phone do |object|
     object.phone.as_json(only: %i[iso prefix number confirmed])

--- a/spec/requests/v1/interventions/predefined_participants/create_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/create_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'POST /v1/interventions/:intervention_id/predefined_participants'
   it 'return correct body' do
     request
     expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id auto_invitation
-                                                                       invitation_sent_at email external_id])
+                                                                       invitation_sent_at email external_id active])
   end
 
   it_behaves_like 'users without access'

--- a/spec/requests/v1/interventions/predefined_participants/index_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/index_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'GET /v1/interventions/:intervention_id/predefined_participants',
   it 'the element from array has correct keys' do
     request
     expect(json_response['data'].first['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id auto_invitation
-                                                                             invitation_sent_at email external_id])
+                                                                             invitation_sent_at email external_id active])
   end
 
   it_behaves_like 'users without access'

--- a/spec/requests/v1/interventions/predefined_participants/update_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/update_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'PATCH /v1/interventions/:intervention_id/predefined_participants
   it 'return correct body' do
     request
     expect(json_response['data']['attributes'].keys).to match_array(%w[full_name first_name last_name phone slug health_clinic_id auto_invitation
-                                                                       invitation_sent_at email external_id])
+                                                                       invitation_sent_at email external_id active])
   end
 
   it 'has correct values' do


### PR DESCRIPTION
## Related tasks
- [CIAS-3733](https://htdevelopers.atlassian.net/browse/CIAS30-3733)

## What's new?
- I have added `active` to predefined_user_serializer
