### PR TITLE
[CIAS30-3737] block sending welcome emails to predefined participants

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -275,7 +275,7 @@ class User < ApplicationRecord
   private
 
   def send_welcome_email
-    return if role?('guest') || role?('preview_session')
+    return if role?('guest') || role?('preview_session') || role?('predefined_participant')
 
     UserMailer.welcome_email(human_readable_role, email).deliver_later
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1009,7 +1009,6 @@ ActiveRecord::Schema.define(version: 2023_10_03_060946) do
     t.boolean "quick_exit_enabled", default: false, null: false
     t.boolean "online", default: false, null: false
     t.uuid "hfhs_patient_detail_id"
-    t.string "language_code", default: "en"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["hfhs_patient_detail_id"], name: "index_users_on_hfhs_patient_detail_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -225,4 +225,15 @@ describe User, type: :model do
       expect { user.confirm }.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
     end
   end
+
+  context 'predefined participant' do
+    it 'doesn\'t receive welcome emails' do
+      expect do
+        described_class.create!(first_name: 'Predefined', last_name: 'User', email: 'predefined_user@example.com', password: 'Password1!',
+                                roles: ['predefined_participant'], terms: true, confirmed_at: DateTime.now)
+      end.not_to change {
+                   ActionMailer::Base.deliveries.size
+                 }
+    end
+  end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3737](https://htdevelopers.atlassian.net/browse/CIAS30-3737)

## What's new?
- detect if a user is a predefined participant and block sending welcome emails to them
