### PR TITLE
[CIAS30-3740] auto-finish block saving answers

### DIFF
--- a/app/controllers/v1/user_sessions/answers_controller.rb
+++ b/app/controllers/v1/user_sessions/answers_controller.rb
@@ -14,6 +14,8 @@ class V1::UserSessions::AnswersController < V1Controller
   end
 
   def create
+    raise ActiveRecord::RecordNotSaved, I18n.t('user_sessions.errors.already_finished') if user_session_load.finished_at?
+
     answer = V1::AnswerService.call(current_v1_user, user_session_id, question_id, answer_params)
     return head answer['status'] if user_session_load.type == 'UserSession::CatMh'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
       cat_mh: "User preview is unavailable for CAT-MH sessions"
   user_sessions:
     errors:
+      already_finished: 'You cannot provide an answer for the finished session'
       previous_question: 'Previous question is unavailable for this type of session'
       scheduled_session: 'You cannot fill scheduled session before the set time'
   teams:

--- a/spec/requests/v1/answers/create_spec.rb
+++ b/spec/requests/v1/answers/create_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe 'POST /v1/user_sessions/:user_session_id/answers', type: :request
     post v1_user_session_answers_path(user_session.id), params: params, headers: user.create_new_auth_token
   end
 
+  context 'when user session is finished' do
+    let(:user) { create(:user, :participant, :confirmed) }
+    let(:user_session) { create(:user_session, user: user, session: session, finished_at: DateTime.now) }
+
+    it 'returns correct http status' do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'return correct error msg' do
+      expect(json_response['message']).to eq 'You cannot provide an answer for the finished session'
+    end
+  end
+
   context 'when creating an answer' do
     %i[admin researcher participant guest].each do |role|
       let(:user) { create(:user, :confirmed, role) }


### PR DESCRIPTION
## Related tasks
- [CIAS-3740](https://htdevelopers.atlassian.net/browse/CIAS30-3740)

## What's new?
- EP to create an answer detects if the user session is finished. In this case, the EP will raise an error with a custom msg 
