### PR TITLE
[CIAS30-3745] block access to deactivated users

### DIFF
--- a/app/controllers/v1/organizations/invitations_controller.rb
+++ b/app/controllers/v1/organizations/invitations_controller.rb
@@ -2,6 +2,7 @@
 
 class V1::Organizations::InvitationsController < V1Controller
   skip_before_action :authenticate_user!, only: %i[confirm]
+  skip_before_action :block_deactivated_account, only: %i[confirm]
 
   def invite_intervention_admin
     authorize! :invite_e_intervention_admin, Organization

--- a/app/controllers/v1_controller.rb
+++ b/app/controllers/v1_controller.rb
@@ -8,6 +8,7 @@ class V1Controller < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
+  before_action :block_deactivated_account
 
   def current_v1_user
     @current_v1_user ||= super
@@ -43,6 +44,12 @@ class V1Controller < ApplicationController
 
   def current_ability
     @current_ability ||= current_v1_user.ability
+  end
+
+  def block_deactivated_account
+    return unless signed_in?
+
+    raise CanCan::AccessDenied, I18n.t('users.deactivated') unless current_v1_user.active
   end
 
   def invalidate_cache(obj)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
       no_email_provided: "E-mail not provided"
       no_phone_number_provided: "Phone number not provided"
   users:
+    deactivated: "This account has been deactivated. Please get in touch with the support if you think it is a mistake."
     invite:
       researcher: The request to invite users as a researcher through emails has been successfully created. We will soon send invitation emails to every user.
       not_active: "Invitation has been cancelled or was already used"

--- a/spec/requests/v1/user_sessions/answers/create_spec.rb
+++ b/spec/requests/v1/user_sessions/answers/create_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe 'POST /v1/user_sessions/:user_session_id/answers', type: :request
         expect(answer.reload.alternative_branch).to be(false)
       end
     end
+
+    it_behaves_like 'deactivated account'
   end
 
   context 'UserSession::CatMh' do

--- a/spec/requests/v1/user_sessions/questions/index_spec.rb
+++ b/spec/requests/v1/user_sessions/questions/index_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'GET /v1/user_session/:user_session_id/question', type: :request 
     let(:user) { participant }
     let(:default_narrator_settings) { { voice: true, animation: true, character: 'peedy' } }
 
+    context 'when user id deactivated' do
+      let(:request) { get v1_user_session_questions_url(user_session.id), headers: user.create_new_auth_token }
+
+      it_behaves_like 'deactivated account'
+    end
+
     context 'when start immediately is set' do
       let!(:answer) { create(:answer_single, question_id: question.id, user_session_id: user_session.id) }
       let!(:session2) { create(:session, intervention_id: intervention.id, schedule: :immediately) }

--- a/spec/requests/v1/user_sessions/show_spec.rb
+++ b/spec/requests/v1/user_sessions/show_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'GET /v1/user_sessions', type: :request do
       request
     end
 
+    it_behaves_like 'deactivated account'
+
     it 'return correct status' do
       expect(response).to have_http_status(:ok)
     end

--- a/spec/support/shared_examples/deactivated_account.rb
+++ b/spec/support/shared_examples/deactivated_account.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'deactivated account' do
+  context 'when current user is deactivated' do
+    let!(:user) { create(:user, :confirmed, active: false) }
+    let(:headers) { user.create_new_auth_token }
+
+    before do
+      request
+    end
+
+    it 'return correct status' do
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'return expected message' do
+      expect(json_response['message']).to eq 'This account has been deactivated. Please get in touch with the support if you think it is a mistake.'
+    end
+  end
+end


### PR DESCRIPTION
## Related tasks
- [CIAS-3745](https://htdevelopers.atlassian.net/browse/CIAS30-3745)

## What's new?
- in the main controller, we detect if a user is activated. Otherwise we raise an error 
