### PR TITLE
[CIAS30-3747] block option to send SMSes to deactivated users

### DIFF
--- a/app/services/v1/intervention/predefined_participants/send_invitation.rb
+++ b/app/services/v1/intervention/predefined_participants/send_invitation.rb
@@ -11,6 +11,7 @@ class V1::Intervention::PredefinedParticipants::SendInvitation
 
   def call
     return if user.phone.blank?
+    raise ActiveRecord::ActiveRecordError, I18n.t('users.invite.predefined.not_active') unless user.active?
 
     sms = Message.create(phone: number, body: content)
     Communication::Sms.new(sms.id).send_message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,8 @@ en:
     invite:
       researcher: The request to invite users as a researcher through emails has been successfully created. We will soon send invitation emails to every user.
       not_active: "Invitation has been cancelled or was already used"
+      predefined:
+        not_active: 'Invitation cannot be sent to a deactivated user'
     preview:
       cat_mh: "User preview is unavailable for CAT-MH sessions"
   user_sessions:

--- a/spec/services/v1/intervention/predefined_participants/send_invitation_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/send_invitation_spec.rb
@@ -29,5 +29,15 @@ RSpec.describe V1::Intervention::PredefinedParticipants::SendInvitation do
       message = Message.order(:created_at).last
       expect(message.body).to include("#{ENV['WEB_URL']}/usr/#{user.predefined_user_parameter.slug}")
     end
+
+    context 'when the user is deactivated' do
+      before do
+        user.update!(active: false)
+      end
+
+      it 'raise an exception' do
+        expect { subject }.to raise_error(ActiveRecord::ActiveRecordError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3747](https://htdevelopers.atlassian.net/browse/CIAS30-3747)

## What's new?
- Detect if a user is deactivated and raise the appropriate error 
