### PR TITLE
[CIAS30-3750] not remove phone if request wants to activate the account

### DIFF
--- a/app/services/v1/intervention/predefined_participants/update_service.rb
+++ b/app/services/v1/intervention/predefined_participants/update_service.rb
@@ -15,7 +15,7 @@ class V1::Intervention::PredefinedParticipants::UpdateService
     ActiveRecord::Base.transaction do
       user.update!(user_params)
       user.predefined_user_parameter.update(predefined_user_parameters)
-      remove_phone! if predefined_user_parameters[:phone_attributes].blank?
+      remove_phone! if remove_phone_number?
     end
     user
   end
@@ -39,5 +39,9 @@ class V1::Intervention::PredefinedParticipants::UpdateService
 
   def remove_phone!
     user.phone&.destroy!
+  end
+
+  def remove_phone_number?
+    user_params[:phone_attributes].blank? && params[:active].blank?
   end
 end

--- a/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/update_service_spec.rb
@@ -70,5 +70,17 @@ RSpec.describe V1::Intervention::PredefinedParticipants::UpdateService do
     it 'remove assigned phone' do
       expect { subject }.to change(Phone, :count).by(-1)
     end
+
+    context 'when a researcher wants to reactivate the user' do
+      let(:params) do
+        {
+          active: true
+        }
+      end
+
+      it 'remove assigned phone' do
+        expect { subject }.not_to change(Phone, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3750](https://htdevelopers.atlassian.net/browse/CIAS30-3750)

## What's new?
- User activation goes to the same endpoint for editing and sends only one parameter(`{active: true}`). Therefore, the logic for deleting the assigned phone number had to be updated to not delete the phone number when the user is activated.
