### PR TITLE
[CIAS30-3759] duplicate and translate intervention's logo

### DIFF
--- a/app/models/concerns/clone/intervention.rb
+++ b/app/models/concerns/clone/intervention.rb
@@ -15,10 +15,18 @@ class Clone::Intervention < Clone::Base
     reassign_branching
     outcome.update!(is_hidden: hidden)
     reset_cache_counters
+    attach_logo
     outcome
   end
 
   private
+
+  def attach_logo
+    return unless source.logo.attachment
+
+    outcome.logo.attach(source.logo.blob)
+    outcome.logo_blob.update!(description: source.logo_blob.description)
+  end
 
   def create_sessions
     source.sessions.order(:position).each do |session|

--- a/app/models/concerns/translate/intervention.rb
+++ b/app/models/concerns/translate/intervention.rb
@@ -5,5 +5,6 @@ class Translate::Intervention < Translate::Base
     source.translation_prefix(destination_language_name_short)
     source.translate_additional_text(translator, source_language_name_short, destination_language_name_short)
     source.translate_sessions(translator, source_language_name_short, destination_language_name_short)
+    source.translate_logo_description(translator, source_language_name_short, destination_language_name_short)
   end
 end

--- a/app/models/intervention.rb
+++ b/app/models/intervention.rb
@@ -203,6 +203,15 @@ class Intervention < ApplicationRecord
     translate_attribute('additional_text', additional_text, translator, source_language_name_short, destination_language_name_short)
   end
 
+  def translate_logo_description(translator, source_language_name_short, destination_language_name_short)
+    return unless logo.attached?
+
+    original_text['image_alt'] = logo_blob.description
+
+    new_value = translator.translate(logo_blob.description, source_language_name_short, destination_language_name_short)
+    logo_blob.update!(description: new_value)
+  end
+
   def translate_sessions(translator, source_language_name_short, destination_language_name_short)
     sessions.each do |session|
       session.translate(translator, source_language_name_short, destination_language_name_short)

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Intervention, type: :model do
         intervention.translate(translator, source_language_name_short, destination_language_name_short)
       end
 
+      it 'has correct value in the original text' do
+        expect(intervention.original_text['image_alt']).to eq 'This is the description'
+      end
+
+      it 'has correctly translated img description' do
+        expect(intervention.logo.description).to eq 'from=>en to=>pl text=>This is the description'
+      end
+
       describe '#translation_prefix' do
         it 'add correct prefix' do
           expect(intervention.reload.name).to include("(#{destination_language_name_short.upcase}) New intervention")
@@ -283,6 +291,15 @@ RSpec.describe Intervention, type: :model do
         cloned_intervention = intervention.clone(params: params)
 
         expect(cloned_intervention.user).to eq(other_user)
+      end
+    end
+
+    context 'when intervention has logo' do
+      let(:intervention) { create(:intervention_with_logo) }
+      let(:cloned_intervention) { intervention.clone }
+
+      it 'logo was cloned' do
+        expect(cloned_intervention.logo.attached?).to be true
       end
     end
   end


### PR DESCRIPTION
## Related tasks
- [CIAS-3759](https://htdevelopers.atlassian.net/browse/CIAS30-3759)

## What's new?
- I have added a logic to duplicate the logo during coping 
- Additionally, translate logo description during translation  
