### PR TITLE
[CIAS30-3793] return session_id when verifying short link of a sequential or fixed-order intervention for the first time as a logged in user

### DIFF
--- a/app/services/concerns/static_link_helper.rb
+++ b/app/services/concerns/static_link_helper.rb
@@ -3,7 +3,7 @@
 module StaticLinkHelper
   def available_now_session(intervention, user_intervention)
     return nil if intervention.sessions.blank?
-    return nil if user_intervention.blank? || user_intervention.completed?
+    return nil if user_intervention&.completed?
 
     user_sessions = UserSession.where(user_intervention: user_intervention).order(:last_answer_at)
     user_sessions_in_progress = user_sessions.where(finished_at: nil).where('scheduled_at IS NULL OR scheduled_at < ?', DateTime.now)

--- a/spec/requests/v1/interventions/short_links/verify_spec.rb
+++ b/spec/requests/v1/interventions/short_links/verify_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'POST /v1/short_links/verify', type: :request do
     it {
       expect(json_response['data'].symbolize_keys).to include({
                                                                 intervention_id: intervention.id,
-                                                                session_id: nil,
+                                                                session_id: session.id,
                                                                 health_clinic_id: nil,
                                                                 multiple_fill_session_available: false,
                                                                 user_intervention_id: nil


### PR DESCRIPTION
## Related tasks
- [CIAS-3793](https://htdevelopers.atlassian.net/browse/CIAS30-3793)

## What's new?
- I've changed the validation to take into account if user_intervention is completed, before we had a wrong check 
