### PR TITLE
[CIAS30-3785] Skip CatMh sessions during exporting

### DIFF
--- a/app/serializers/v1/export/intervention_serializer.rb
+++ b/app/serializers/v1/export/intervention_serializer.rb
@@ -5,7 +5,9 @@ class V1::Export::InterventionSerializer < ActiveModel::Serializer
 
   attributes :quick_exit, :type, :shared_to, :additional_text, :original_text, :current_narrator
 
-  has_many :sessions, serializer: V1::Export::SessionSerializer
+  has_many :sessions, serializer: V1::Export::SessionSerializer do
+    object.sessions.where(type: 'Session::Classic')
+  end
   has_many :intervention_accesses, serializer: V1::Export::InterventionAccessSerializer
 
   attribute :name do


### PR DESCRIPTION
## Related tasks
- [CIAS-3785](https://htdevelopers.atlassian.net/browse/CIAS30-3785)

## What's new?
- add where to has_many: sessions to skip CatMh sessions during exporting 
