### PR TITLE
[CIAS30-3791] a participant skips phone screen

### DIFF
--- a/app/services/v1/sms_plans/schedule_sms_for_user_session.rb
+++ b/app/services/v1/sms_plans/schedule_sms_for_user_session.rb
@@ -190,7 +190,7 @@ class V1::SmsPlans::ScheduleSmsForUserSession
   end
 
   def timezone
-    timezone_defined_by_user = phone_answer&.migrated_body&.dig('data', 0, 'value', 'timezone').to_s
+    timezone_defined_by_user = value_provided_by_the_user.present? ? value_provided_by_the_user['timezone'].to_s : ''
     ActiveSupport::TimeZone[timezone_defined_by_user].present? ? timezone_defined_by_user : Phonelib.parse(phone.full_number).timezone
   end
 
@@ -199,7 +199,15 @@ class V1::SmsPlans::ScheduleSmsForUserSession
   end
 
   def time_ranges_defined_by_user
-    @time_ranges_defined_by_user = phone_answer&.migrated_body&.dig('data', 0, 'value', 'time_ranges')
+    @time_ranges_defined_by_user ||= if value_provided_by_the_user.present?
+                                       value_provided_by_the_user['time_ranges']
+                                     else
+                                       ''
+                                     end
+  end
+
+  def value_provided_by_the_user
+    @value_provided_by_the_user ||= phone_answer&.migrated_body&.dig('data', 0, 'value')
   end
 
   def random_time


### PR DESCRIPTION
## Related tasks
- [CIAS-3791](https://htdevelopers.atlassian.net/browse/CIAS30-3791)

## What's new?
- When a user had a confirmed phone number and, while filling out, decided to skip answering the question or the session ended on its own an error was thrown. Now in this case the default setting is taken. 
