### PR TITLE
[CIAS30-3810] incorrect flag when the intervention contains multiple-fill sessions

### DIFF
--- a/app/services/concerns/static_link_helper.rb
+++ b/app/services/concerns/static_link_helper.rb
@@ -23,9 +23,10 @@ module StaticLinkHelper
   end
 
   def multiple_fill_session_available(user_intervention)
+    # require 'pry'; binding.pry
     finished_multiple_fill_user_sessions = UserSession.joins(:session).where(user_intervention: user_intervention,
                                                                              session: { multiple_fill: true }).where.not(finished_at: nil)
-    user_sessions_in_progress = UserSession.where(user_intervention: user_intervention, finished_at: nil)
+    user_sessions_in_progress = UserSession.where(user_intervention: user_intervention, finished_at: nil, started: true)
 
     finished_multiple_fill_user_sessions.any? && user_sessions_in_progress.blank?
   end

--- a/spec/requests/v1/interventions/short_links/verify_spec.rb
+++ b/spec/requests/v1/interventions/short_links/verify_spec.rb
@@ -143,6 +143,68 @@ RSpec.describe 'POST /v1/short_links/verify', type: :request do
     }
   end
 
+  context 'sequential intervention with finished session (multiple-fill)' do
+    let(:intervention) { create(:intervention, :published, user: researcher) }
+    let!(:session1) { create(:session, intervention: intervention, position: 1, multiple_fill: true) }
+    let!(:session2) { create(:session, intervention: intervention, position: 2) }
+    let!(:user_intervention) { create(:user_intervention, intervention: intervention, user: participant) }
+    let!(:user_session) { create(:user_session, user_intervention: user_intervention, user: participant, session: session1, finished_at: DateTime.now) }
+
+    context 'only first session is finished' do
+      before do
+        request
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it {
+        expect(json_response['data'].symbolize_keys).to include({
+                                                                  intervention_id: intervention.id,
+                                                                  health_clinic_id: nil,
+                                                                  session_id: session2.id,
+                                                                  multiple_fill_session_available: true,
+                                                                  user_intervention_id: user_intervention.id
+                                                                })
+      }
+    end
+
+    context 'next session is created but not started' do
+      let!(:user_session2) { create(:user_session, user_intervention: user_intervention, user: participant, session: session2) }
+
+      before do
+        request
+      end
+
+      it {
+        expect(json_response['data'].symbolize_keys).to include({
+                                                                  intervention_id: intervention.id,
+                                                                  health_clinic_id: nil,
+                                                                  session_id: session2.id,
+                                                                  multiple_fill_session_available: true,
+                                                                  user_intervention_id: user_intervention.id
+                                                                })
+      }
+    end
+
+    context 'when second session is started' do
+      let!(:user_session2) { create(:user_session, user_intervention: user_intervention, user: participant, session: session2, started: true) }
+
+      before do
+        request
+      end
+
+      it {
+        expect(json_response['data'].symbolize_keys).to include({
+                                                                  intervention_id: intervention.id,
+                                                                  health_clinic_id: nil,
+                                                                  session_id: session2.id,
+                                                                  multiple_fill_session_available: false,
+                                                                  user_intervention_id: user_intervention.id
+                                                                })
+      }
+    end
+  end
+
   context 'sequential module intervention with sessions' do
     let(:intervention) { create(:flexible_order_intervention, :published, user: researcher) }
     let!(:session) { create(:session, intervention: intervention) }

--- a/spec/services/v1/intervention/predefined_participants/verify_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/verify_service_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe V1::Intervention::PredefinedParticipants::VerifyService do
     context 'multiple-fill session is finished but next session is already started' do
       let(:second_user_session) do
         create(:user_session, session: predefined_user_parameters.intervention.sessions.order(:position).second, user: predefined_participant,
-                              user_intervention: user_intervention)
+                              user_intervention: user_intervention, started: true)
       end
 
       before do


### PR DESCRIPTION
## Related tasks
- [CIAS-3810](https://htdevelopers.atlassian.net/browse/CIAS30-3810)

## What's new?
- set the correct status for `multiple_fill_session_available` 
