### PR TITLE
[CIAS30-3815] fix issue with SMS-STOP-functionality

### DIFF
--- a/app/controllers/v1/twillo_message_controller.rb
+++ b/app/controllers/v1/twillo_message_controller.rb
@@ -15,14 +15,14 @@ class V1::TwilloMessageController < V1Controller
   end
 
   def from
-    params[:from]
+    transformed_params[:from]
   end
 
   def to
-    params[:to]
+    transformed_params[:to]
   end
 
   def body
-    params[:body]
+    transformed_params[:body]
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3815](https://htdevelopers.atlassian.net/browse/CIAS30-3815)

## What's new?
- use `transformed_params` instead of `params` 
