### PR TITLE
[CIAS30-3819] Unify errors returned when verifying short links and predefined participants links

### DIFF
--- a/app/services/v1/short_links/map_service.rb
+++ b/app/services/v1/short_links/map_service.rb
@@ -58,6 +58,8 @@ class V1::ShortLinks::MapService
 
     raise ComplexException.new(I18n.t('short_link.error.not_available'), { reason: 'INTERVENTION_DRAFT' }, :bad_request) if intervention.draft?
 
+    raise ComplexException.new(I18n.t('short_link.error.not_available'), { reason: 'INTERVENTION_PAUSED' }, :bad_request) if intervention.paused?
+
     raise ComplexException.new(I18n.t('short_link.error.not_available'), { reason: 'INTERVENTION_CLOSED' }, :bad_request)
   end
 

--- a/spec/requests/v1/interventions/predefined_participants/verify_spec.rb
+++ b/spec/requests/v1/interventions/predefined_participants/verify_spec.rb
@@ -15,7 +15,32 @@ RSpec.describe 'POST /v1/predefined_participants/verify', type: :request do
 
   it 'when the slug is correct but intervention is draft' do
     request
-    expect(response).to have_http_status(:forbidden)
+    expect(response).to have_http_status(:bad_request)
+    expect(json_response).to include({ 'message' => 'Intervention is not available', 'details' => { 'reason' => 'INTERVENTION_DRAFT' } })
+  end
+
+  context 'when intervention is paused' do
+    before do
+      user.predefined_user_parameter.intervention.update!(status: :paused)
+    end
+
+    it 'returns correct status and error message' do
+      request
+      expect(response).to have_http_status(:bad_request)
+      expect(json_response).to include({ 'message' => 'Intervention is not available', 'details' => { 'reason' => 'INTERVENTION_PAUSED' } })
+    end
+  end
+
+  context 'when intervention is closed/archived' do
+    before do
+      user.predefined_user_parameter.intervention.update!(status: :closed)
+    end
+
+    it 'returns correct status and error message' do
+      request
+      expect(response).to have_http_status(:bad_request)
+      expect(json_response).to include({ 'message' => 'Intervention is not available', 'details' => { 'reason' => 'INTERVENTION_CLOSED' } })
+    end
   end
 
   context 'when intervention is published' do

--- a/spec/requests/v1/interventions/short_links/verify_spec.rb
+++ b/spec/requests/v1/interventions/short_links/verify_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe 'POST /v1/short_links/verify', type: :request do
     }
   end
 
+  context 'when intervention is paused' do
+    let(:intervention) { create(:intervention, :paused, user: researcher) }
+
+    before do
+      request
+    end
+
+    it { expect(response).to have_http_status(:bad_request) }
+
+    it {
+      expect(json_response).to include({ 'message' => 'Intervention is not available', 'details' => { 'reason' => 'INTERVENTION_PAUSED' } })
+    }
+  end
+
   context 'quest without access' do
     let(:user) { create(:user, :guest, :confirmed) }
     let(:intervention) { create(:intervention, :published, user: researcher, shared_to: 'registered') }


### PR DESCRIPTION
## Related tasks
- [CIAS-3819](https://htdevelopers.atlassian.net/browse/CIAS30-3819)

## What's new?
- in `predefined_participants/verify` detect case when intervention is draft/paused/closed/archived
- add case with paused intervention to `short_link/verify` 
