### PR TITLE
[CIAS30-3839] User intervention id isn't returned when verifying predefined participant link to reporting intervention

### DIFF
--- a/app/services/v1/intervention/predefined_participants/verify_service.rb
+++ b/app/services/v1/intervention/predefined_participants/verify_service.rb
@@ -15,7 +15,7 @@ class V1::Intervention::PredefinedParticipants::VerifyService
     {
       intervention_id: predefined_user_parameters.intervention_id,
       session_id: available_now_session(intervention, user_intervention)&.id,
-      health_clinic_id: predefined_user_parameters.health_clinic_id,
+      health_clinic_id: health_clinic_id,
       multiple_fill_session_available: multiple_fill_session_available(user_intervention),
       user_intervention_id: user_intervention.id
     }
@@ -26,10 +26,15 @@ class V1::Intervention::PredefinedParticipants::VerifyService
   private
 
   def user_intervention
-    @user_intervention ||= UserIntervention.find_or_create_by(user_id: predefined_user_parameters.user_id, intervention_id: intervention.id)
+    @user_intervention ||= UserIntervention.find_or_create_by(user_id: predefined_user_parameters.user_id, intervention_id: intervention.id,
+                                                              health_clinic_id: health_clinic_id)
   end
 
   def intervention
     @intervention ||= predefined_user_parameters.intervention
+  end
+
+  def health_clinic_id
+    @health_clinic_id ||= predefined_user_parameters.health_clinic_id
   end
 end

--- a/spec/services/v1/intervention/predefined_participants/verify_service_spec.rb
+++ b/spec/services/v1/intervention/predefined_participants/verify_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe V1::Intervention::PredefinedParticipants::VerifyService do
       expect { subject }.to change(UserIntervention, :count).by(1)
     end
 
-    it 'when intervention deesn\'t have sessions' do
+    it 'when intervention doesn\'t have sessions' do
       expect(subject[:session_id]).to be nil
     end
   end
@@ -127,6 +127,20 @@ RSpec.describe V1::Intervention::PredefinedParticipants::VerifyService do
       it 'multiple fill session available should return nil if user has other session in progress' do
         expect(subject[:multiple_fill_session_available]).to be false
       end
+    end
+  end
+
+  context 'flexible intervention inside organization' do
+    let(:organization) { create(:organization, :with_health_clinics) }
+
+    before do
+      intervention = predefined_user_parameters.intervention
+      intervention.update!(organization: organization, type: 'Intervention::FlexibleOrder')
+      predefined_user_parameters.update!(health_clinic: organization.health_systems.first.health_clinics.first)
+    end
+
+    it 'return user intervention' do
+      expect { subject }.to change(UserIntervention, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3839](https://htdevelopers.atlassian.net/browse/CIAS30-3839)

## What's new?
- add missing argument when we fetch or create a user intervention for the predefined participant -> health clinic id 
