### PR TITLE
[CIAS30-3823] block option to create new user session after close

### DIFF
--- a/app/controllers/v1/user_sessions_controller.rb
+++ b/app/controllers/v1/user_sessions_controller.rb
@@ -5,6 +5,7 @@ class V1::UserSessionsController < V1Controller
   before_action :validate_intervention_status
 
   def create
+    validate_session_status
     user_session = V1::UserSessions::CreateService.call(session_id, user_id, health_clinic_id)
     authorize! :create, user_session
     user_session.save!
@@ -84,10 +85,6 @@ class V1::UserSessionsController < V1Controller
     user_session_params[:session_id]
   end
 
-  def session
-    @session ||= Session.find(session_id)
-  end
-
   def user_session_id
     params[:user_session_id]
   end
@@ -116,8 +113,8 @@ class V1::UserSessionsController < V1Controller
   end
 
   def validate_session_status
-    return unless session.autoclose_enabled
+    return unless session_load.autoclose_enabled
 
-    raise ComplexException.new(I18n.t('sessions.closed'), { reason: 'SESSION_CLOSED' }, :bad_request) if Time.zone.now > session.autoclose_at
+    raise ComplexException.new(I18n.t('sessions.closed'), { reason: 'SESSION_CLOSED' }, :bad_request) if Time.zone.now > session_load.autoclose_at
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
       index:
         csv: The request to send the CSV file has been successfully created. We will soon send an email to you with the request status.
   sessions:
+    closed: 'You try to fill session after the time defined by researcher'
     sms_alerts:
       no_data_provided: "No personal data provided"
       no_first_name_provided: "First name not provided"

--- a/spec/requests/v1/user_sessions/create_spec.rb
+++ b/spec/requests/v1/user_sessions/create_spec.rb
@@ -55,5 +55,5 @@ RSpec.describe 'POST /v1/user_sessions', type: :request do
 
   it_behaves_like 'paused intervention'
 
-  # it_behaves_like 'closed session'
+  it_behaves_like 'closed session'
 end

--- a/spec/requests/v1/user_sessions/create_spec.rb
+++ b/spec/requests/v1/user_sessions/create_spec.rb
@@ -54,4 +54,6 @@ RSpec.describe 'POST /v1/user_sessions', type: :request do
   it_behaves_like 'create user session'
 
   it_behaves_like 'paused intervention'
+
+  # it_behaves_like 'closed session'
 end

--- a/spec/requests/v1/user_sessions/fetch_or_create_spec.rb
+++ b/spec/requests/v1/user_sessions/fetch_or_create_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe 'POST /v1/user_sessions', type: :request do
 
   it_behaves_like 'paused intervention'
 
+  it_behaves_like 'closed session'
+
   context 'exists' do
     let!(:user_int) { create(:user_intervention, intervention: intervention, user: user, status: 'in_progress') }
     let!(:user_session) { create(:user_session, user: user, session: session, user_intervention: user_int) }

--- a/spec/support/shared_examples/closed_session.rb
+++ b/spec/support/shared_examples/closed_session.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'closed session' do
-  let!(:intervention) { create(:intervention, :paused, user_id: user.id) }
+  let!(:intervention) { create(:intervention, user_id: user.id) }
   let!(:session) { create(:session, intervention: intervention, autoclose_enabled: true, autoclose_at: (DateTime.now - 2.days)) }
 
   before { request }

--- a/spec/support/shared_examples/closed_session.rb
+++ b/spec/support/shared_examples/closed_session.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'closed session' do
+  let!(:intervention) { create(:intervention, :paused, user_id: user.id) }
+  let!(:session) { create(:session, intervention: intervention, autoclose_enabled: true, autoclose_at: (DateTime.now - 2.days)) }
+
+  before { request }
+
+  it 'returns correct response code' do
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it 'returns proper error message' do
+    expect(json_response['message']).to include('You try to fill session after the time defined by researcher')
+  end
+end


### PR DESCRIPTION
## Related tasks
- [CIAS-3823](https://htdevelopers.atlassian.net/browse/CIAS30-3823)

## What's new?
- block option to create new user session after close
