### PR TITLE
[CIAS30-3811] change the place from where we get the "started_at" value in the CSV file 

### DIFF
--- a/app/models/intervention/csv/harvester.rb
+++ b/app/models/intervention/csv/harvester.rb
@@ -95,7 +95,7 @@ class Intervention::Csv::Harvester
 
   def metadata(session, user_session, row_index, approach_number, multiple_fill)
     session_headers_index = header.index(column_name(multiple_fill, session, 'metadata.session_start', approach_number))
-    session_start = user_session.created_at
+    session_start = user_session.answers.first&.created_at || user_session.created_at
     session_end = user_session.finished_at
     unless session_end.nil?
       rows[row_index][session_headers_index + 2] = time_diff(session_start, session_end) # session duration

--- a/spec/models/intervention/csv/harvester_spec.rb
+++ b/spec/models/intervention/csv/harvester_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
         expect(subject.header).to eq [:user_id, :email, "#{session.variable}.dep_severity", "#{session.variable}.dep_precision",
                                       "#{session.variable}.mhm_severity", "#{session.variable}.metadata.session_start",
                                       "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-        expect(subject.rows).to eq [[user_session.user_id, user_session.user.email, '1', '2', '7.8', user_session.created_at, nil, nil]]
+        expect(subject.rows).to eq [[user_session.user_id, user_session.user.email, '1', '2', '7.8', user_session.answers.first.created_at, nil, nil]]
       end
     end
 
@@ -88,7 +88,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.answers.first.created_at, nil,
+                                       nil]]
         end
 
         context 'set correct order based on question group position' do
@@ -120,7 +121,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
             expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_2", "#{session.variable}.test",
                                           "#{session.variable}.metadata.session_start", "#{session.variable}.metadata.session_end",
                                           "#{session.variable}.metadata.session_duration"]
-            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '2', '1', answer.user_session.created_at, nil, nil]]
+            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '2', '1', answer.user_session.answers.first.created_at,
+                                         nil, nil]]
           end
         end
       end
@@ -162,7 +164,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_1", "#{session.variable}.test_2",
                                         "#{session.variable}.metadata.session_start", "#{session.variable}.metadata.session_end",
                                         "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1', '2', answer.user_session.created_at, nil,
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1', '2', answer.created_at, nil,
                                        nil]]
         end
       end
@@ -195,7 +197,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_1", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1', answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1',
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -225,7 +228,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_1", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 1, answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 1, answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -270,7 +273,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_1", "#{session.variable}.test_2",
                                         "#{session.variable}.metadata.session_start", "#{session.variable}.metadata.session_end",
                                         "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email, '1', '2', answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email, '1', '2',
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -303,7 +307,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_1", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 1, answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 1, answer.created_at, nil, nil]]
         end
       end
 
@@ -335,7 +339,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.site", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, true, answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, true,
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -365,8 +370,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.date", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '2012-12-12', answer.user_session.created_at,
-                                       nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '2012-12-12',
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -397,7 +402,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.phone", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
           expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '{provided_number => +48123123123}',
-                                       answer.user_session.created_at, nil, nil]]
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
 
         context 'with selected time ranges' do
@@ -425,7 +430,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
                                           "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
             expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s,
                                          '{provided_number => +48123123123, selected_time_ranges => [{"from"=>7, "to"=>9, "label"=>"early_morning"}], timezone => Europe/Warsaw}',
-                                         answer.user_session.created_at, nil, nil]]
+                                         answer.user_session.answers.first.created_at, nil, nil]]
           end
           # rubocop:enable Layout/LineLength
         end
@@ -457,7 +462,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.currency", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1000 USD', answer.user_session.created_at, nil,
+          expect(subject.rows).to eq [[answer.user_session.user_id.to_s, answer.user_session.user.email.to_s, '1000 USD', answer.created_at, nil,
                                        nil]]
         end
       end
@@ -525,7 +530,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
               answer1.user_session.user_id.to_s,
               answer1.user_session.user.email.to_s,
               '1', nil, nil, { 'name' => 'John', 'phonetic_name' => 'John' },
-              answer1.user_session.created_at, nil, nil
+              answer1.created_at, nil, nil
             ]
           ]
         end
@@ -552,7 +557,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
           expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email,
                                        { 'value' => 'test@tes.com', 'numeric_value' => '1', 'report_template' => ['report_name'] },
-                                       answer.user_session.created_at, nil, nil]]
+                                       answer.user_session.answers.first.created_at, nil, nil]]
         end
       end
 
@@ -610,8 +615,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
         it 'save the values into one row' do
           subject.collect
           expect(subject.rows.size).to eq 1
-          expect(subject.rows).to eq [[answer2.user_session.user_id.to_s, answer2.user_session.user.email.to_s, '1', answer.user_session.created_at, nil, nil,
-                                       '3', answer2.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer2.user_session.user_id.to_s, answer2.user_session.user.email.to_s, '1', answer.created_at, nil, nil,
+                                       '3', answer2.created_at, nil, nil]]
         end
       end
 
@@ -642,7 +647,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 888, answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, 888, answer.created_at, nil, nil]]
         end
       end
 
@@ -661,14 +666,15 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
         let!(:answer) { create(:answer_single, question: question, skipped: true, user_session: user_session) }
 
         before do
-          user_session.update!(finished_at: user_session.created_at + 5.hours)
+          user_session.update!(finished_at: answer.created_at + 5.hours)
         end
 
         it 'correctly shows an end date & session duration' do
           subject.collect
           expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test", "#{session.variable}.metadata.session_start",
                                         "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-          expect(subject.rows).to eq [[user_session.user.id, user_session.user.email, 888, user_session.created_at, user_session.finished_at, '05:00:00']]
+          expect(subject.rows).to eq [[user_session.user.id, user_session.user.email, 888, user_session.answers.first.created_at, user_session.finished_at,
+                                       '05:00:00']]
         end
 
         context 'when more than 1 session is finished' do
@@ -701,14 +707,14 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
           end
           let(:expected_rows) do
             [
-              [user.id, user.email, 888, user_session1.created_at, user_session1.finished_at, '05:00:00', 888, user_session2.created_at,
-               user_session2.finished_at, '06:50:40']
+              [user.id, user.email, 888, user_session1.answers.first.created_at, user_session1.finished_at, '05:00:00', 888,
+               user_session2.answers.first.created_at, user_session2.finished_at, '06:50:40']
             ]
           end
 
           before do
-            user_session1.update!(finished_at: user_session1.created_at + 5.hours)
-            user_session2.update!(finished_at: user_session2.created_at + 6.hours + 50.minutes + 40.seconds)
+            user_session1.update!(finished_at: user_session1.answers.first.created_at + 5.hours)
+            user_session2.update!(finished_at: user_session2.answers.first.created_at + 6.hours + 50.minutes + 40.seconds)
           end
 
           it 'correctly shows end dates & durations' do
@@ -961,7 +967,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
                                         "#{session.variable}.approach_number_1.metadata.session_start",
                                         "#{session.variable}.approach_number_1.metadata.session_end",
                                         "#{session.variable}.approach_number_1.metadata.session_duration"]
-          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.created_at, nil, nil]]
+          expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.answers.first.created_at, nil,
+                                       nil]]
         end
 
         context 'when number of attempts is empty' do
@@ -973,7 +980,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
                                           "#{session.variable}.approach_number_1.metadata.session_start",
                                           "#{session.variable}.approach_number_1.metadata.session_end",
                                           "#{session.variable}.approach_number_1.metadata.session_duration"]
-            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.created_at, nil, nil]]
+            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.answers.first.created_at, nil,
+                                         nil]]
           end
         end
       end
@@ -998,7 +1006,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
 
             expect(subject.rows.first).to include(user.id, user.email, patient_details.patient_id, patient_details.first_name, patient_details.last_name,
                                                   patient_details.dob, patient_details.sex, patient_details.zip_code, patient_details.phone_number,
-                                                  patient_details.phone_type, user_session.created_at, nil, nil)
+                                                  patient_details.phone_type, user_session.answers.first.created_at, nil, nil)
           end
 
           context 'unfinished user_session - without assigned hfhs_user_detail' do
@@ -1012,7 +1020,7 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
                                                 "#{session.variable}.metadata.session_duration")
 
               expect(subject.rows.first).to include(user.id, user.email, nil, nil, nil,
-                                                    nil, nil, nil, user_session.created_at, nil, nil)
+                                                    nil, nil, nil, user_session.answers.first.created_at, nil, nil)
             end
           end
         end
@@ -1044,7 +1052,8 @@ RSpec.describe Intervention::Csv::Harvester, type: :model do
             subject.collect
             expect(subject.header).to eq [:user_id, :email, "#{session.variable}.test_hf", "#{session.variable}.metadata.session_start",
                                           "#{session.variable}.metadata.session_end", "#{session.variable}.metadata.session_duration"]
-            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.created_at, nil, nil]]
+            expect(subject.rows).to eq [[answer.user_session.user_id, answer.user_session.user.email, '1', answer.user_session.answers.first.created_at, nil,
+                                         nil]]
           end
         end
       end


### PR DESCRIPTION
## Related tasks
- [CIAS-3811](https://htdevelopers.atlassian.net/browse/CIAS30-3811)

## What's new?
- in the CSV file, we have the date of the answer to the first question in the started at column instead of the date the session user was created 
