### PR TITLE
[CIAS30-3891] set blocked to false if user has assigned predefined participant role

### DIFF
--- a/app/serializers/v1/user_intervention_serializer.rb
+++ b/app/serializers/v1/user_intervention_serializer.rb
@@ -17,12 +17,12 @@ class V1::UserInterventionSerializer < V1Serializer
   end
 
   attribute :blocked do |object|
-   object.intervention.shared_to_invited? &&
+    object.intervention.shared_to_invited? &&
       object.intervention.intervention_accesses
             .pluck(:email)
             .map(&:downcase)
             .exclude?(object.user.email) &&
-        object.user.roles.exclude?('predefined_participant')
+      object.user.roles.exclude?('predefined_participant')
   end
 
   attribute :intervention do |object|

--- a/app/serializers/v1/user_intervention_serializer.rb
+++ b/app/serializers/v1/user_intervention_serializer.rb
@@ -17,7 +17,15 @@ class V1::UserInterventionSerializer < V1Serializer
   end
 
   attribute :blocked do |object|
-    object.intervention.shared_to_invited? && object.intervention.intervention_accesses.pluck(:email).map(&:downcase).exclude?(object.user.email)
+    if object.intervention.shared_to_invited?
+      object.intervention.intervention_accesses
+            .pluck(:email)
+            .map(&:downcase)
+            .exclude?(object.user.email) &&
+        object.user.roles.exclude?('predefined_participant')
+    else
+      false
+    end
   end
 
   attribute :intervention do |object|

--- a/app/serializers/v1/user_intervention_serializer.rb
+++ b/app/serializers/v1/user_intervention_serializer.rb
@@ -17,15 +17,12 @@ class V1::UserInterventionSerializer < V1Serializer
   end
 
   attribute :blocked do |object|
-    if object.intervention.shared_to_invited?
+   object.intervention.shared_to_invited? &&
       object.intervention.intervention_accesses
             .pluck(:email)
             .map(&:downcase)
             .exclude?(object.user.email) &&
         object.user.roles.exclude?('predefined_participant')
-    else
-      false
-    end
   end
 
   attribute :intervention do |object|

--- a/spec/requests/v1/user_interventions/show_spec.rb
+++ b/spec/requests/v1/user_interventions/show_spec.rb
@@ -63,4 +63,19 @@ RSpec.describe 'GET /v1/user_interventions/:id', type: :request do
       expect(json_response['data']['attributes']['user_sessions']['data'].map { |us| us['attributes']['filled_out_count'] }).to include(0, 1)
     }
   end
+
+  context 'predefined participnat has access to session shared to invited' do
+    let!(:intervention) { create(:flexible_order_intervention, user: user, status: 'published', shared_to: 'invited') }
+    let!(:user) { create(:user, :predefined_participant, :confirmed) }
+
+    before { request }
+
+    it 'returns correct HTTP status code (OK)' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns correct blocked status' do
+      expect(json_response['data']['attributes']['blocked']).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
## Related tasks
- [CIAS-3891](https://htdevelopers.atlassian.net/browse/CIAS30-3891)

## What's new?
- Detect if a user is the predefined participant and set `blocked` to true 
