### PR TITLE
[CIAS30-3980] Reports are not being sent on new production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ end
 
 group :test, :production do
   # only version that is working on AWS
-  gem 'wkhtmltopdf-heroku', '2.12.6.0'
+  gem 'wkhtmltopdf-heroku', '3.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -638,7 +638,7 @@ GEM
       ostruct
     with_env (1.1.0)
     wkhtmltopdf-binary (0.12.6.8)
-    wkhtmltopdf-heroku (2.12.6.0)
+    wkhtmltopdf-heroku (3.0.0)
     xml-simple (1.1.9)
       rexml
     zeitwerk (2.6.18)
@@ -732,7 +732,7 @@ DEPENDENCIES
   webmock
   wicked_pdf
   wkhtmltopdf-binary
-  wkhtmltopdf-heroku (= 2.12.6.0)
+  wkhtmltopdf-heroku (= 3.0.0)
 
 RUBY VERSION
    ruby 3.1.4p223


### PR DESCRIPTION
## Related tasks
- [CIAS30-3980](https://htdevelopers.atlassian.net/browse/CIAS30-3980)

## What's new?
-  new version of heroku stack do not support previous version of wkhtmltopdf
