### PR TITLE
[CIAS30-4131] Add `+Add link` functionality to the SMS Messaging > Use Formula

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,7 +665,7 @@ GEM
     xml-simple (1.1.9)
       rexml
     zeitwerk (2.7.4)
-    zlib (3.2.1)
+    zlib (3.2.3)
 
 PLATFORMS
   ruby

--- a/app/controllers/v1/sms_links_controller.rb
+++ b/app/controllers/v1/sms_links_controller.rb
@@ -5,8 +5,11 @@ class V1::SmsLinksController < V1Controller
 
   def index
     authorize! :read, sms_link_sms_plan
-
-    collection = sms_link_sms_plan.sms_links
+    collection = if sms_link_params[:variant_id].present?
+                   SmsPlan::Variant.find(sms_link_params[:variant_id]).sms_links
+                 else
+                   sms_link_sms_plan.no_formula_sms_links
+                 end
 
     render json: serialized_response(collection)
   end
@@ -34,7 +37,11 @@ class V1::SmsLinksController < V1Controller
   end
 
   def sms_link_sms_plan
-    @sms_link_sms_plan ||= SmsPlan.find(sms_link_params[:sms_plan_id])
+    @sms_link_sms_plan ||= if sms_link_params[:variant_id].present?
+                             SmsPlan::Variant.find(sms_link_params[:variant_id]).sms_plan
+                           else
+                             SmsPlan.find(sms_link_params[:sms_plan_id])
+                           end
   end
 
   def verify_response
@@ -59,7 +66,8 @@ class V1::SmsLinksController < V1Controller
       :url,
       :link_type,
       :variable,
-      :sms_plan_id
+      :sms_plan_id,
+      :variant_id
     )
   end
 end

--- a/app/controllers/v1/sms_plans_controller.rb
+++ b/app/controllers/v1/sms_plans_controller.rb
@@ -14,7 +14,7 @@ class V1::SmsPlansController < V1Controller
   def show
     authorize! :read, sms_plan
 
-    render json: V1::SmsPlanSerializer.new(sms_plan, { include: %i[variants phones sms_links] })
+    render json: V1::SmsPlanSerializer.new(sms_plan, { include: %i[variants phones no_formula_sms_links] })
   end
 
   def create

--- a/app/models/concerns/clone/session.rb
+++ b/app/models/concerns/clone/session.rb
@@ -166,14 +166,24 @@ class Clone::Session < Clone::Base
       new_sms_plan.no_formula_attachment.attach(plan.no_formula_attachment.blob) if plan.no_formula_attachment.attached?
       outcome.sms_plans << new_sms_plan
 
-      plan.variants.each { |variant| create_and_assign_variant(variant, new_sms_plan) }
+      variant_id_mapping = {}
+      plan.variants.each do |variant|
+        new_variant = create_and_assign_variant(variant, new_sms_plan)
+        variant_id_mapping[variant.id] = new_variant.id
+      end
 
       plan.alert_phones.each do |alert_phone|
         new_sms_plan.alert_phones << AlertPhone.new(sms_plan: new_sms_plan, phone: alert_phone.phone)
       end
 
       plan.sms_links.each do |sms_link|
-        new_sms_plan.sms_links << SmsLink.new(url: sms_link.url, link_type: sms_link.link_type, session: source, variable: sms_link.variable)
+        new_variant_id = sms_link.variant_id.present? ? variant_id_mapping[sms_link.variant_id] : nil
+        new_sms_plan.sms_links << SmsLink.new(
+          url: sms_link.url,
+          link_type: sms_link.link_type,
+          variable: sms_link.variable,
+          variant_id: new_variant_id
+        )
       end
     end
   end
@@ -217,5 +227,6 @@ class Clone::Session < Clone::Base
     new_variant = SmsPlan::Variant.new(variant.slice(SmsPlan::Variant::ATTR_NAMES_TO_COPY))
     new_variant.attachment.attach(variant.attachment.blob) if variant.attachment.attached?
     new_sms_plan.variants << new_variant
+    new_variant
   end
 end

--- a/app/models/concerns/clone/sms_plan.rb
+++ b/app/models/concerns/clone/sms_plan.rb
@@ -16,9 +16,11 @@ class Clone::SmsPlan < Clone::Base
   private
 
   def create_sms_variants
+    @variant_id_mapping = {}
     source.variants.find_each do |variant|
-      newly_created_variant = SmsPlan::Variant.create(variant.slice(SmsPlan::Variant::ATTR_NAMES_TO_COPY).merge(sms_plan_id: outcome.id))
-      newly_created_variant.attachment.attach(variant.attachment.blob) if variant.attachment.attached?
+      new_variant = SmsPlan::Variant.create(variant.slice(SmsPlan::Variant::ATTR_NAMES_TO_COPY).merge(sms_plan_id: outcome.id))
+      new_variant.attachment.attach(variant.attachment.blob) if variant.attachment.attached?
+      @variant_id_mapping[variant.id] = new_variant.id
     end
   end
 
@@ -38,7 +40,14 @@ class Clone::SmsPlan < Clone::Base
 
   def create_sms_links
     source.sms_links.find_each do |sms_link|
-      outcome.sms_links << SmsLink.new(sms_plan: outcome, url: sms_link.url, link_type: sms_link.link_type, variable: sms_link.variable)
+      new_variant_id = sms_link.variant_id.present? ? @variant_id_mapping[sms_link.variant_id] : nil
+      outcome.sms_links << SmsLink.new(
+        sms_plan: outcome,
+        url: sms_link.url,
+        link_type: sms_link.link_type,
+        variable: sms_link.variable,
+        variant_id: new_variant_id
+      )
     end
   end
 end

--- a/app/models/intervention/csv/harvester.rb
+++ b/app/models/intervention/csv/harvester.rb
@@ -82,7 +82,8 @@ class Intervention::Csv::Harvester
 
   def sms_link_column_prefix(sms_plan_index, sms_link)
     if sms_link.variant_id.present?
-      "sms_messaging#{sms_plan_index}.variant_#{sms_link.variant.position}.link_#{sms_link.variable}"
+      variant_pos = (sms_link.variant&.position || 0) + 1
+      "sms_messaging#{sms_plan_index}.variant_#{variant_pos}.link_#{sms_link.variable}"
     else
       "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}"
     end

--- a/app/models/intervention/csv/harvester.rb
+++ b/app/models/intervention/csv/harvester.rb
@@ -71,12 +71,21 @@ class Intervention::Csv::Harvester
     column_names = []
     session.sms_plans.each_with_index do |sms_plan, sms_plan_index|
       sms_plan.sms_links.find_each do |sms_link|
-        column_names << [column_name(multiple_fill, session, "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}.timestamps", index + 1),
-                         column_name(multiple_fill, session, "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}.totalclicks", index + 1)]
+        prefix = sms_link_column_prefix(sms_plan_index, sms_link)
+        column_names << [column_name(multiple_fill, session, "#{prefix}.timestamps", index + 1),
+                         column_name(multiple_fill, session, "#{prefix}.totalclicks", index + 1)]
       end
     end
 
     column_names
+  end
+
+  def sms_link_column_prefix(sms_plan_index, sms_link)
+    if sms_link.variant_id.present?
+      "sms_messaging#{sms_plan_index}.variant_#{sms_link.variant.position}.link_#{sms_link.variable}"
+    else
+      "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}"
+    end
   end
 
   def information_only_screen_videos_header(session, index, multiple_fill)
@@ -209,11 +218,12 @@ class Intervention::Csv::Harvester
   def sms_links(session, user_session, row_index, approach_number, multiple_fill)
     session.sms_plans.each_with_index do |sms_plan, sms_plan_index|
       sms_plan.sms_links.find_each do |sms_link|
+        prefix = sms_link_column_prefix(sms_plan_index, sms_link)
         session_header_index = header.index(
-          column_name(multiple_fill, session, "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}.timestamps", approach_number)
+          column_name(multiple_fill, session, "#{prefix}.timestamps", approach_number)
         )
         total_clicks_index = header.index(
-          column_name(multiple_fill, session, "sms_messaging#{sms_plan_index}.link_#{sms_link.variable}.totalclicks", approach_number)
+          column_name(multiple_fill, session, "#{prefix}.totalclicks", approach_number)
         )
         user_id = user_session.user_id
 

--- a/app/models/sms_link.rb
+++ b/app/models/sms_link.rb
@@ -4,10 +4,15 @@ class SmsLink < ApplicationRecord
   # ASSOCIATIONS
   belongs_to :sms_plan
   belongs_to :session
+  belongs_to :variant, class_name: 'SmsPlan::Variant', optional: true
   has_many :sms_links_users, dependent: :destroy
 
   # VALIDATIONS
-  validates :url, :variable, presence: true, uniqueness: { scope: :sms_plan_id }
+  validates :url, :variable, presence: true
+  validates :url, :variable, uniqueness: { scope: :sms_plan_id, conditions: -> { where(variant_id: nil) } },
+                             if: -> { variant_id.nil? }
+  validates :url, :variable, uniqueness: { scope: :variant_id },
+                             if: -> { variant_id.present? }
 
   # ENUMS
   enum :link_type, {
@@ -16,12 +21,13 @@ class SmsLink < ApplicationRecord
   }
 
   # CALLBACKS
-  before_validation :set_session_id
+  before_validation :set_derived_ids
   before_validation :add_https_to_url
 
   # METHODS
-  def set_session_id
-    self.session_id ||= sms_plan&.session_id
+  def set_derived_ids
+    self.sms_plan_id ||= variant&.sms_plan_id
+    self.session_id  ||= sms_plan&.session_id
   end
 
   def add_https_to_url

--- a/app/models/sms_plan.rb
+++ b/app/models/sms_plan.rb
@@ -14,6 +14,7 @@ class SmsPlan < ApplicationRecord
   belongs_to :session, counter_cache: true
   has_many :variants, class_name: 'SmsPlan::Variant', dependent: :destroy
   has_many :sms_links, dependent: :destroy
+  has_many :no_formula_sms_links, -> { where(variant_id: nil) }, class_name: 'SmsLink', inverse_of: :sms_plan, dependent: :destroy
   has_one_attached :no_formula_attachment, dependent: :purge_later
 
   attribute :original_text, :json, default: -> { assign_default_values('original_text') }

--- a/app/models/sms_plan/variant.rb
+++ b/app/models/sms_plan/variant.rb
@@ -6,6 +6,7 @@ class SmsPlan::Variant < ApplicationRecord
   has_paper_trail
   belongs_to :sms_plan
   has_one_attached :attachment, dependent: :purge_later
+  has_many :sms_links, inverse_of: :variant, dependent: :destroy
 
   CURRENT_VERSION = '1'
 

--- a/app/serializers/v1/export/sms_link_serializer.rb
+++ b/app/serializers/v1/export/sms_link_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class V1::Export::SmsLinkSerializer < ActiveModel::Serializer
+  attributes :url, :link_type, :variable
+end

--- a/app/serializers/v1/export/sms_plan_serializer.rb
+++ b/app/serializers/v1/export/sms_plan_serializer.rb
@@ -6,6 +6,7 @@ class V1::Export::SmsPlanSerializer < ActiveModel::Serializer
               :schedule_variable, :sms_send_time_type, :sms_send_time_details
 
   has_many :variants, serializer: V1::Export::SmsPlanVariantSerializer
+  has_many :no_formula_sms_links, key: :sms_links, serializer: V1::Export::SmsLinkSerializer
 
   attribute :version do
     SmsPlan::CURRENT_VERSION

--- a/app/serializers/v1/export/sms_plan_variant_serializer.rb
+++ b/app/serializers/v1/export/sms_plan_variant_serializer.rb
@@ -3,6 +3,8 @@
 class V1::Export::SmsPlanVariantSerializer < ActiveModel::Serializer
   attributes :formula_match, :content, :original_text, :position
 
+  has_many :sms_links, serializer: V1::Export::SmsLinkSerializer
+
   attribute :version do
     SmsPlan::Variant::CURRENT_VERSION
   end

--- a/app/serializers/v1/sms_link_serializer.rb
+++ b/app/serializers/v1/sms_link_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class V1::SmsLinkSerializer < V1Serializer
-  attributes :session_id, :url, :link_type, :sms_plan_id, :variable
+  attributes :session_id, :url, :link_type, :sms_plan_id, :variable, :variant_id
 end

--- a/app/serializers/v1/sms_plan/variant_serializer.rb
+++ b/app/serializers/v1/sms_plan/variant_serializer.rb
@@ -5,6 +5,8 @@ class V1::SmsPlan::VariantSerializer < V1Serializer
 
   attributes :formula_match, :content, :original_text, :position
 
+  has_many :sms_links, serializer: V1::SmsLinkSerializer
+
   attribute :attachment do |object|
     map_file_data(object.attachment) if object.attachment.attached?
   end

--- a/app/serializers/v1/sms_plan_serializer.rb
+++ b/app/serializers/v1/sms_plan_serializer.rb
@@ -8,7 +8,7 @@ class V1::SmsPlanSerializer < V1Serializer
              :include_email, :include_phone_number, :schedule_variable, :sms_send_time_type, :sms_send_time_details
   has_many :variants, serializer: V1::SmsPlan::VariantSerializer
   has_many :phones, serializer: V1::PhoneSerializer
-  has_many :sms_links, serializer: V1::SmsLinkSerializer
+  has_many :no_formula_sms_links, serializer: V1::SmsLinkSerializer
 
   attribute :end_at do |object|
     object.end_at.strftime('%d/%m/%Y') if object.end_at.present?

--- a/app/services/concerns/sms_helper.rb
+++ b/app/services/concerns/sms_helper.rb
@@ -41,8 +41,9 @@ module SmsHelper
     content
   end
 
-  def insert_links_into_variant(content, plan)
-    plan.sms_links.each do |sms_link|
+  def insert_links_into_variant(content, plan, variant = nil)
+    links = variant.present? ? variant.sms_links : plan.no_formula_sms_links
+    links.each do |sms_link|
       sms_links_user = sms_link.sms_links_users.create!(user: user)
       content.gsub!("::#{sms_link.variable}::", "#{ENV.fetch('WEB_URL')}/link/#{sms_links_user.slug}")
     end

--- a/app/services/import/basic/sms_link_service.rb
+++ b/app/services/import/basic/sms_link_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Import::Basic::SmsLinkService
+  attr_reader :sms_plan_id, :sms_link_hash, :variant_id
+
+  def self.call(sms_plan_id, sms_link_hash, variant_id: nil)
+    new(sms_plan_id, sms_link_hash, variant_id: variant_id).call
+  end
+
+  def initialize(sms_plan_id, sms_link_hash, variant_id: nil)
+    @sms_plan_id = sms_plan_id
+    @sms_link_hash = sms_link_hash
+    @variant_id = variant_id
+  end
+
+  def call
+    SmsLink.create!(
+      sms_plan_id: sms_plan_id,
+      variant_id: variant_id,
+      url: sms_link_hash[:url],
+      link_type: sms_link_hash[:link_type],
+      variable: sms_link_hash[:variable]
+    )
+  end
+end

--- a/app/services/import/basic/sms_plan_service.rb
+++ b/app/services/import/basic/sms_plan_service.rb
@@ -16,9 +16,13 @@ class Import::Basic::SmsPlanService
 
   def call
     variants = sms_plan_hash.delete(:variants)
+    sms_links = sms_plan_hash.delete(:sms_links)
     sms_plan = SmsPlan.create!(sms_plan_hash.merge({ session_id: session_id }))
     variants&.each do |variant_hash|
       get_import_service_class(variant_hash, SmsPlan::Variant).call(sms_plan.id, variant_hash)
+    end
+    sms_links&.each do |sms_link_hash|
+      Import::Basic::SmsLinkService.call(sms_plan.id, sms_link_hash)
     end
     sms_plan
   end

--- a/app/services/import/basic/sms_plan_variant_service.rb
+++ b/app/services/import/basic/sms_plan_variant_service.rb
@@ -16,8 +16,12 @@ class Import::Basic::SmsPlanVariantService
   end
 
   def call
+    sms_links = sms_plan_variant_hash.delete(:sms_links)
     variant = SmsPlan::Variant.create!(sms_plan_variant_hash.merge(sms_plan_id: sms_plan_id))
     variant.update!(position: position)
+    sms_links&.each do |sms_link_hash|
+      Import::Basic::SmsLinkService.call(sms_plan_id, sms_link_hash, variant_id: variant.id)
+    end
     variant
   end
 end

--- a/app/services/v1/sms_plans/schedule_sms_for_user_session.rb
+++ b/app/services/v1/sms_plans/schedule_sms_for_user_session.rb
@@ -83,13 +83,14 @@ class V1::SmsPlans::ScheduleSmsForUserSession
 
   def set_frequency(start_time, plan, send_first_right_after_finish = false)
     frequency = plan.frequency
-    content = sms_content(plan)
+    variant = plan.is_used_formula ? matched_variant(plan) : nil
+    content = variant&.content || plan.no_formula_text
 
     return if content.blank?
 
     attachment_url = attachment_url(plan)
     content = insert_variables_into_variant(content)
-    content = insert_links_into_variant(content, plan)
+    content = insert_links_into_variant(content, plan, variant)
     content = add_predefined_participant_indicator_to_invitation_link(content)
     finish_date = plan.end_at
 

--- a/db/migrate/20260311130114_add_variant_id_to_sms_links.rb
+++ b/db/migrate/20260311130114_add_variant_id_to_sms_links.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddVariantIdToSmsLinks < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :sms_links, :variant, type: :uuid, null: true, foreign_key: { to_table: :sms_plan_variants }, index: true
+
+    # Replace the existing full unique index with a partial one scoped to no-formula links (variant_id IS NULL)
+    remove_index :sms_links, name: 'index_sms_links_on_sms_plan_id_and_variable'
+    add_index :sms_links, %i[sms_plan_id variable], unique: true,
+              where: 'variant_id IS NULL',
+              name: 'index_sms_links_on_sms_plan_id_and_variable'
+
+    # Partial unique index for formula (variant-scoped) links
+    add_index :sms_links, %i[variant_id variable], unique: true,
+              where: 'variant_id IS NOT NULL',
+              name: 'index_sms_links_on_variant_id_and_variable'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_24_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_11_130114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"
@@ -856,9 +856,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_24_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "variable", null: false
+    t.uuid "variant_id"
     t.index ["session_id"], name: "index_sms_links_on_session_id"
-    t.index ["sms_plan_id", "variable"], name: "index_sms_links_on_sms_plan_id_and_variable", unique: true
+    t.index ["sms_plan_id", "variable"], name: "index_sms_links_on_sms_plan_id_and_variable", unique: true, where: "(variant_id IS NULL)"
     t.index ["sms_plan_id"], name: "index_sms_links_on_sms_plan_id"
+    t.index ["variant_id", "variable"], name: "index_sms_links_on_variant_id_and_variable", unique: true, where: "(variant_id IS NOT NULL)"
+    t.index ["variant_id"], name: "index_sms_links_on_variant_id"
   end
 
   create_table "sms_links_users", force: :cascade do |t|
@@ -1188,6 +1191,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_24_000000) do
   add_foreign_key "sms_codes", "health_clinics"
   add_foreign_key "sms_codes", "sessions"
   add_foreign_key "sms_links", "sessions"
+  add_foreign_key "sms_links", "sms_plan_variants", column: "variant_id"
   add_foreign_key "sms_links", "sms_plans"
   add_foreign_key "sms_links_users", "sms_links"
   add_foreign_key "sms_links_users", "users"

--- a/spec/factories/sms_links.rb
+++ b/spec/factories/sms_links.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     sequence(:url) { 'google.com' }
     sequence(:link_type) { 'website' }
     sequence(:variable) { |n| "link_variable_#{n}" }
+
+    trait :with_variant do
+      association(:variant, factory: :sms_plan_variant)
+      sms_plan { variant.sms_plan }
+      session { variant.sms_plan.session }
+    end
   end
 end

--- a/spec/models/sms_link_spec.rb
+++ b/spec/models/sms_link_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmsLink, type: :model do
+  describe 'associations' do
+    it { should belong_to(:sms_plan) }
+    it { should belong_to(:session) }
+    it { should belong_to(:variant).optional }
+  end
+
+  describe '#set_derived_ids' do
+    context 'when only variant_id is provided (no sms_plan_id / session_id from caller)' do
+      let(:sms_plan) { create(:sms_plan) }
+      let(:variant)  { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      it 'derives sms_plan_id from the variant' do
+        sms_link = described_class.create!(variant: variant, url: 'https://test.com', link_type: 'website', variable: 'v1')
+        expect(sms_link.sms_plan_id).to eq(sms_plan.id)
+      end
+
+      it 'derives session_id from the variant\'s sms_plan' do
+        sms_link = described_class.create!(variant: variant, url: 'https://test.com', link_type: 'website', variable: 'v1')
+        expect(sms_link.session_id).to eq(sms_plan.session_id)
+      end
+    end
+  end
+
+  describe 'uniqueness validation' do
+    let(:sms_plan) { create(:sms_plan) }
+
+    context 'no-formula (variant_id nil)' do
+      before { create(:sms_link, sms_plan: sms_plan, session: sms_plan.session, variable: 'promo') }
+
+      it 'rejects a duplicate variable in the same plan' do
+        duplicate = described_class.new(sms_plan: sms_plan, session: sms_plan.session,
+                                        url: 'https://x.com', link_type: 'website', variable: 'promo')
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:variable]).to be_present
+      end
+
+      it 'allows the same variable name in a different plan' do
+        other_plan = create(:sms_plan, session: sms_plan.session)
+        sibling = described_class.new(sms_plan: other_plan, session: sms_plan.session,
+                                      url: 'https://x.com', link_type: 'website', variable: 'promo')
+        expect(sibling).to be_valid
+      end
+    end
+
+    context 'formula (variant_id present)' do
+      let(:variant_a) { create(:sms_plan_variant, sms_plan: sms_plan) }
+      let(:variant_b) { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      before { create(:sms_link, variant: variant_a, sms_plan: sms_plan, session: sms_plan.session, variable: 'offer') }
+
+      it 'rejects a duplicate variable in the same variant' do
+        duplicate = described_class.new(variant: variant_a, sms_plan: sms_plan, session: sms_plan.session,
+                                        url: 'https://x.com', link_type: 'website', variable: 'offer')
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:variable]).to be_present
+      end
+
+      it 'allows the same variable name in a different variant' do
+        cross_variant = described_class.new(variant: variant_b, sms_plan: sms_plan, session: sms_plan.session,
+                                            url: 'https://x.com', link_type: 'website', variable: 'offer')
+        expect(cross_variant).to be_valid
+      end
+    end
+
+    context 'mixed modes' do
+      let(:variant) { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      before { create(:sms_link, sms_plan: sms_plan, session: sms_plan.session, variable: 'shared') }
+
+      it 'allows the same variable in both no-formula and variant scopes' do
+        variant_link = described_class.new(variant: variant, sms_plan: sms_plan, session: sms_plan.session,
+                                           url: 'https://x.com', link_type: 'website', variable: 'shared')
+        expect(variant_link).to be_valid
+      end
+    end
+  end
+end

--- a/spec/requests/v1/sms_links/create_spec.rb
+++ b/spec/requests/v1/sms_links/create_spec.rb
@@ -70,6 +70,87 @@ RSpec.describe 'POST /v1/sms_links', type: :request do
         )
       end
     end
+
+    context 'when variant_id is provided (formula variant link)' do
+      let(:no_formula_text) { '' }
+      let(:variant) { create(:sms_plan_variant, sms_plan: sms_plan) }
+      let(:params) do
+        {
+          sms_link: {
+            url: 'https://test.com',
+            link_type: 'website',
+            variant_id: variant.id,
+            variable: 'variable_1'
+          }
+        }
+      end
+
+      it 'returns :created status' do
+        request
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'creates sms link scoped to the variant' do
+        expect { request }.to change(SmsLink, :count).by(1)
+
+        expect(SmsLink.last).to have_attributes(
+          variant_id: variant.id,
+          sms_plan_id: sms_plan.id,
+          session_id: sms_plan.session.id,
+          variable: 'variable_1'
+        )
+      end
+
+      it 'includes variant_id in the response' do
+        request
+        expect(json_response['data']['attributes']['variant_id']).to eq(variant.id)
+      end
+    end
+
+    context 'when same variable name is used in two different variants' do
+      let(:no_formula_text) { '' }
+      let(:params) do
+        {
+          sms_link: {
+            url: 'https://test.com',
+            link_type: 'website',
+            variant_id: variant_b.id,
+            variable: 'shared_var'
+          }
+        }
+      end
+      let(:variant_a) { create(:sms_plan_variant, sms_plan: sms_plan) }
+      let(:variant_b) { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      before { create(:sms_link, variant: variant_a, sms_plan: sms_plan, session: sms_plan.session, variable: 'shared_var') }
+
+      it 'returns :created status (no uniqueness collision across variants)' do
+        request
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'when same variable name is used in no-formula and a variant' do
+      let(:no_formula_text) { 'Test: ::shared_var::' }
+      let(:params) do
+        {
+          sms_link: {
+            url: 'https://test.com',
+            link_type: 'website',
+            variant_id: variant.id,
+            variable: 'shared_var'
+          }
+        }
+      end
+      let(:variant) { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      before { create(:sms_link, sms_plan: sms_plan, session: sms_plan.session, variable: 'shared_var') }
+
+      it 'returns :created status (no collision between no-formula and variant scopes)' do
+        request
+        expect(response).to have_http_status(:created)
+      end
+    end
   end
 
   context 'when params are invalid' do
@@ -91,6 +172,32 @@ RSpec.describe 'POST /v1/sms_links', type: :request do
 
     it 'does NOT create SMS link' do
       expect { request }.not_to change(SmsLink, :count)
+    end
+
+    context 'when same variable is used twice in the same variant' do
+      let(:no_formula_text) { '' }
+      let(:params) do
+        {
+          sms_link: {
+            url: 'https://test.com',
+            link_type: 'website',
+            variant_id: variant.id,
+            variable: 'dup_var'
+          }
+        }
+      end
+      let(:variant) { create(:sms_plan_variant, sms_plan: sms_plan) }
+
+      before { create(:sms_link, variant: variant, sms_plan: sms_plan, session: sms_plan.session, variable: 'dup_var') }
+
+      it 'returns :unprocessable_entity' do
+        request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does NOT create SMS link' do
+        expect { request }.not_to change(SmsLink, :count)
+      end
     end
   end
 end

--- a/spec/requests/v1/sms_plans/show_spec.rb
+++ b/spec/requests/v1/sms_plans/show_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe 'GET /v1/sms_plans/:id', type: :request do
         'attributes' => include(
           'formula_match' => variant.formula_match,
           'content' => variant.content
-        )
+        ),
+        'relationships' => include('sms_links' => hash_including('data' => []))
       )
       expect(json_response['included']).to include(
         'id' => variant2.id,
@@ -53,7 +54,8 @@ RSpec.describe 'GET /v1/sms_plans/:id', type: :request do
         'attributes' => include(
           'formula_match' => variant2.formula_match,
           'content' => variant2.content
-        )
+        ),
+        'relationships' => include('sms_links' => hash_including('data' => []))
       )
     end
 

--- a/spec/services/concerns/sms_helper_spec.rb
+++ b/spec/services/concerns/sms_helper_spec.rb
@@ -158,4 +158,53 @@ RSpec.describe SmsHelper do
       end
     end
   end
+
+  describe '#insert_links_into_variant' do
+    let(:plan) { create(:sms_plan, session: session) }
+    let(:no_formula_link) { create(:sms_link, sms_plan: plan, session: session, variable: 'promo') }
+
+    context 'when variant is nil (no-formula mode)' do
+      before { no_formula_link }
+
+      it 'creates SmsLinksUser entries for no-formula links only' do
+        expect { helper.insert_links_into_variant('Click ::promo::'.dup, plan) }
+          .to change(SmsLinksUser, :count).by(1)
+      end
+
+      it 'replaces the token with the short link' do
+        result = helper.insert_links_into_variant('Click ::promo::'.dup, plan)
+        expect(result).to match(%r{/link/})
+        expect(result).not_to include('::promo::')
+      end
+
+      it 'does not process variant-scoped links' do
+        variant = create(:sms_plan_variant, sms_plan: plan)
+        create(:sms_link, variant: variant, sms_plan: plan, session: session, variable: 'offer')
+        result = helper.insert_links_into_variant('::promo:: ::offer::'.dup, plan)
+        expect(result).to include('::offer::')  # variant link not substituted
+      end
+    end
+
+    context 'when variant is provided (formula mode)' do
+      let(:variant) { create(:sms_plan_variant, sms_plan: plan) }
+      let!(:variant_link) { create(:sms_link, variant: variant, sms_plan: plan, session: session, variable: 'offer') }
+
+      it 'creates SmsLinksUser entries for variant links only' do
+        expect { helper.insert_links_into_variant('Buy ::offer::'.dup, plan, variant) }
+          .to change(SmsLinksUser, :count).by(1)
+      end
+
+      it 'replaces the token with the short link' do
+        result = helper.insert_links_into_variant('Buy ::offer::'.dup, plan, variant)
+        expect(result).to match(%r{/link/})
+        expect(result).not_to include('::offer::')
+      end
+
+      it 'does not process no-formula links' do
+        no_formula_link
+        result = helper.insert_links_into_variant('::promo:: ::offer::'.dup, plan, variant)
+        expect(result).to include('::promo::')  # no-formula link not substituted
+      end
+    end
+  end
 end

--- a/spec/services/import/v1/sms_plan/variant_service_spec.rb
+++ b/spec/services/import/v1/sms_plan/variant_service_spec.rb
@@ -25,4 +25,29 @@ RSpec.describe Import::V1::SmsPlan::VariantService do
       SmsPlan::Variant.first.attributes.transform_keys(&:to_sym).except(:updated_at, :created_at, :sms_plan_id, :id)
     ).to include(sms_plan_variant_hash.except(:version))
   end
+
+  context 'when sms_links are present in the hash (variant-level links)' do
+    before do
+      sms_plan_variant_hash[:sms_links] = [
+        { url: 'https://offer.example.com', link_type: 'video', variable: 'offer' }
+      ]
+    end
+
+    it 'creates the sms_links' do
+      expect { subject }.to change(SmsLink, :count).by(1)
+    end
+
+    it 'creates sms_links scoped to the new variant' do
+      subject
+      variant = SmsPlan::Variant.last
+      link = SmsLink.last
+      expect(link).to have_attributes(
+        url: 'https://offer.example.com',
+        link_type: 'video',
+        variable: 'offer',
+        variant_id: variant.id,
+        sms_plan_id: sms_plan.id
+      )
+    end
+  end
 end

--- a/spec/services/import/v1/sms_plan_service_spec.rb
+++ b/spec/services/import/v1/sms_plan_service_spec.rb
@@ -41,4 +41,28 @@ RSpec.describe Import::V1::SmsPlanService do
     # because it differs by like 100 milliseconds so we have to compare strings
     expect(sms_plan_hash[:end_at].in_time_zone('UTC').strftime(fmt)).to eq SmsPlan.first.end_at.in_time_zone('UTC').strftime(fmt)
   end
+
+  context 'when sms_links are present in the hash (no-formula links)' do
+    before do
+      sms_plan_hash[:sms_links] = [
+        { url: 'https://promo.example.com', link_type: 'website', variable: 'promo' }
+      ]
+    end
+
+    it 'creates the sms_links' do
+      expect { subject }.to change(SmsLink, :count).by(1)
+    end
+
+    it 'creates sms_links with correct attributes and no variant_id' do
+      subject
+      link = SmsLink.last
+      expect(link).to have_attributes(
+        url: 'https://promo.example.com',
+        link_type: 'website',
+        variable: 'promo',
+        variant_id: nil
+      )
+      expect(link.sms_plan_id).to eq(SmsPlan.last.id)
+    end
+  end
 end


### PR DESCRIPTION
- Introduced variant_id to SmsLink model and updated associations.
- Enhanced SMS link creation to support variant-specific links.
- Updated serializers to include variant_id in responses.
- Modified SMS link retrieval logic to differentiate between formula and no-formula links.
- Added tests for variant handling in SMS links.

## Related tasks
- [CIAS-4131](https://htdevelopers.atlassian.net/browse/CIAS30-4131)

## What's new?
- 
