### PR TITLE
[CIAS30-4159] Add handling for unanswered questions in chart statistics creation

### DIFF
--- a/app/models/chart.rb
+++ b/app/models/chart.rb
@@ -54,7 +54,6 @@ class Chart < ApplicationRecord
     available_vars = intervention_question_variables(intervention)
 
     missing_vars.reject do |var|
-      # Remove session prefix
       var_name = var.split('.').last
       available_vars.include?(var_name)
     end
@@ -63,11 +62,11 @@ class Chart < ApplicationRecord
   private
 
   def intervention_question_variables(intervention)
-    @intervention_question_variables ||= begin
-      questions = ::Question.joins(question_group: :session)
-                            .where(sessions: { intervention_id: intervention.id })
-
-      questions.flat_map(&:question_variables).compact.uniq
-    end
+    # Keyed by intervention.id: a Chart instance can be called with different interventions.
+    @intervention_question_variables ||= {}
+    @intervention_question_variables[intervention.id] ||= ::Question
+      .joins(question_group: :session)
+      .where(sessions: { intervention_id: intervention.id })
+      .flat_map(&:question_variables).compact.uniq
   end
 end

--- a/app/services/v1/chart_statistics/create.rb
+++ b/app/services/v1/chart_statistics/create.rb
@@ -27,8 +27,16 @@ class V1::ChartStatistics::Create
         return
       end
 
-      valid_vars = missing_vars - invalid_vars
-      Rails.logger.info("ChartStatistics::Create chart_id=#{chart.id}: missing variables from unselected options (will be set to 0): #{valid_vars.inspect}")
+      if any_owning_question_unanswered?(missing_vars)
+        Rails.logger.info(
+          "ChartStatistics::Create SKIPPED chart_id=#{chart.id}: " \
+          "user_session=#{user_session.id} did not reach all questions referenced by formula " \
+          "(branched-around or partial completion). Formula: #{formula['payload']}"
+        )
+        return
+      end
+
+      Rails.logger.info("ChartStatistics::Create chart_id=#{chart.id}: missing variables from unselected options (will be set to 0): #{missing_vars.inspect}")
     end
     return if formula_error?
     return if zero_division_error?
@@ -115,5 +123,26 @@ class V1::ChartStatistics::Create
     return false if chart.date_range_end.present? && chart.date_range_end + 1.day <= user_session.finished_at
 
     true
+  end
+
+  def any_owning_question_unanswered?(missing_vars)
+    return false if missing_vars.empty?
+
+    required_var_names = missing_vars.map { |v| v.split('.').last }
+
+    owning_question_ids = Question.joins(question_group: :session)
+                                  .where(sessions: { intervention_id: user_session.session.intervention_id })
+                                  .select { |q| q.question_variables.compact.intersect?(required_var_names) }
+                                  .map(&:id)
+    return false if owning_question_ids.empty?
+
+    latest_user_session_ids = user_session.user_intervention.latest_user_sessions.map(&:id)
+
+    answered_question_ids = Answer.confirmed
+                                  .where(user_session_id: latest_user_session_ids,
+                                         question_id: owning_question_ids)
+                                  .pluck(:question_id).uniq
+
+    (owning_question_ids - answered_question_ids).any?
   end
 end

--- a/spec/models/chart_spec.rb
+++ b/spec/models/chart_spec.rb
@@ -204,5 +204,26 @@ RSpec.describe Chart do
       expect(result).to match_array(%w[var1 var2])
       expect(result).not_to include('other_var')
     end
+
+    it 'caches per-intervention so successive calls with different interventions return their own questions' do
+      # Regression: previously the result was memoized in a single ivar without
+      # keying on intervention, so a Chart instance reused across multiple
+      # interventions (CreateForUserSessions bulk path) would lock in the first
+      # intervention's vars and misclassify formulas for the rest.
+      other_intervention = create(:intervention, :published, organization: organization)
+      other_session = create(:session, intervention: other_intervention, variable: 'session1')
+      other_question_group = create(:question_group, session: other_session)
+      create(:question_single, question_group: other_question_group, body: {
+               data: [{ payload: 'option1', value: '1' }],
+               variable: { name: 'other_intervention_var' }
+             })
+
+      first_result = chart.send(:intervention_question_variables, intervention)
+      second_result = chart.send(:intervention_question_variables, other_intervention)
+
+      expect(first_result).to match_array(%w[var1 var2])
+      expect(second_result).to contain_exactly('other_intervention_var')
+      expect(second_result).not_to include('var1', 'var2')
+    end
   end
 end

--- a/spec/services/v1/chart_statistics/create_spec.rb
+++ b/spec/services/v1/chart_statistics/create_spec.rb
@@ -118,7 +118,10 @@ RSpec.describe V1::ChartStatistics::Create do
       end
 
       # User only selected option_1, but formula references all options
-      let!(:answer_multi) { create(:answer_multiple, user_session: user_session, body: { data: [{ var: 'option_1', value: '1' }] }) }
+      let!(:answer_multi) do
+        create(:answer_multiple, user_session: user_session, question: multiple_question,
+                                 body: { data: [{ var: 'option_1', value: '1' }] })
+      end
 
       let(:formula) do
         {
@@ -252,6 +255,13 @@ RSpec.describe V1::ChartStatistics::Create do
                })
       end
 
+      # User reached the grid question and answered both rows; the answer must
+      # be tied to grid_question so the new owning-question guard sees it as answered.
+      let!(:answer_grid) do
+        create(:answer_grid, user_session: user_session, question: grid_question,
+                             body: { data: [{ var: 'row1', value: '3' }, { var: 'row2', value: '4' }] })
+      end
+
       let(:formula) do
         {
           'payload' => 'session_var.row1 + session_var.row2',
@@ -286,6 +296,79 @@ RSpec.describe V1::ChartStatistics::Create do
       it 'creates chart statistic without validation logic' do
         expect(chart).not_to receive(:validate_formula_variables)
         expect { subject }.to change(ChartStatistic, :count).by(1)
+      end
+    end
+
+    context 'when user did not reach all questions referenced by formula (branched-around)' do
+      # Simulates: user declined a gating question (e.g. terms) and branched
+      # straight to Finish, never reaching the EPDS-style screening questions.
+      let!(:terms_question) do
+        create(:question_single, question_group: question_group, body: {
+                 data: [{ payload: 'Yes', value: '1' }],
+                 variable: { name: 'terms' }
+               })
+      end
+
+      let!(:terms_answer) do
+        create(:answer_single, user_session: user_session, question: terms_question,
+                               body: { data: [{ var: 'terms', value: '1' }] })
+      end
+
+      let!(:epds_questions) do
+        (1..3).map do |i|
+          create(:question_single, question_group: question_group, body: {
+                   data: [{ payload: 'Yes', value: '1' }],
+                   variable: { name: "epds#{i}" }
+                 })
+        end
+      end
+
+      let(:formula) do
+        {
+          'payload' => 'session_var.epds1 + session_var.epds2 + session_var.epds3',
+          'patterns' => [{ 'match' => '>=2', 'label' => 'Positive', 'color' => '#C766EA' }],
+          'default_pattern' => { 'label' => 'Negative', 'color' => '#E2B1F4' }
+        }
+      end
+
+      it 'does not create chart statistic' do
+        expect { subject }.not_to change(ChartStatistic, :count)
+      end
+
+      it 'logs the skip with the branched-around message' do
+        allow(Rails.logger).to receive(:info)
+        subject
+        expect(Rails.logger).to have_received(:info).with(/did not reach all questions referenced by formula/)
+      end
+    end
+
+    context 'when user reached only some of the referenced questions (partial completion)' do
+      let!(:epds_questions) do
+        (1..3).map do |i|
+          create(:question_single, question_group: question_group, body: {
+                   data: [{ payload: 'Yes', value: '1' }],
+                   variable: { name: "epds#{i}" }
+                 })
+        end
+      end
+
+      let!(:partial_answers) do
+        epds_questions.first(2).map do |q|
+          create(:answer_single, user_session: user_session, question: q,
+                                 body: { data: [{ var: q.body['variable']['name'], value: '1' }] })
+        end
+      end
+
+      let(:formula) do
+        {
+          'payload' => 'session_var.epds1 + session_var.epds2 + session_var.epds3',
+          'patterns' => [{ 'match' => '>=2', 'label' => 'Positive', 'color' => '#C766EA' }],
+          'default_pattern' => { 'label' => 'Negative', 'color' => '#E2B1F4' }
+        }
+      end
+
+      it 'does not create chart statistic' do
+        expect { subject }.not_to change(ChartStatistic, :count)
       end
     end
   end


### PR DESCRIPTION
- Implemented a guard to skip chart statistic creation if the user did not reach all questions referenced by the formula.
- Enhanced logging to indicate when chart creation is skipped due to incomplete responses.
- Updated tests to cover scenarios where users branch around questions or provide partial answers.## Related tasks

- [CIAS-4159](https://htdevelopers.atlassian.net/browse/CIAS30-4159)

## What's new?
- 
