### PR TITLE
chore: bump gems flagged by bundler-audit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
@@ -214,7 +214,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.6.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -417,13 +417,13 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oj (3.16.13)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     orm_adapter (0.5.0)


### PR DESCRIPTION
- concurrent-ruby 1.3.6 -> 1.3.7 (CVE-2026-54904/54905/54906)
- faraday 2.14.2 -> 2.14.3 (CVE-2026-54297, DoS)
- nokogiri 1.19.3 -> 1.19.4 (11 advisories)
- oj 3.16.13 -> 3.17.3 (CVE-2026-54500/54502/54592)

bundler-audit check: no vulnerabilities found.

## Related tasks
- [CIAS-](https://htdevelopers.atlassian.net/browse/CIAS30-)

## What's new?
- 
