### PR TITLE
CIAS30-4198 Back-port SSL connection adjustment to dev

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -164,14 +164,9 @@ EPIC_ON_FHIR_APPOINTMENTS_ENDPOINT=https://fhir.epic.com/example/appointments
 EPIC_ON_FHIR_KID=YOUR-KID
 EPIC_ON_FHIR_SYSTEM_IDENTIFIER=KEY_TO_IDENTIFYING_SPECIFIC_SYSTEM
 EPIC_ON_FHIR_SYSTEM="urn:oid:1.2.840.114350.1.13.338.3.7.5.737384.48"
-# Optional. TLS verification of HFH's gateway is always on. Set this ONLY if the
-# gateway serves an incomplete certificate chain; paste the PEM of HFH's issuing
-# intermediate CA (added to the system roots at request time). Leave unset when
-# the gateway presents a complete chain.
-# EPIC_ON_FHIR_CA_CERT="-----BEGIN CERTIFICATE-----
-# ...
-# -----END CERTIFICATE-----
-# "
+# EPIC_ON_FHIR_CA_PIN_INTERMEDIATE=true
+# EPIC_ON_FHIR_CA_INTERMEDIATE_CERT="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+# EPIC_ON_FHIR_CA_ROOT_CERT="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
 
 #FAXes
 BASE_DOCUMO_URL='https://api.sandbox.documo.com'

--- a/app/services/api/epic_on_fhir/ssl_options.rb
+++ b/app/services/api/epic_on_fhir/ssl_options.rb
@@ -1,25 +1,41 @@
 # frozen_string_literal: true
 
 # Builds the Faraday SSL options for outbound calls to HFH's Epic-on-FHIR
-# gateway. TLS verification is always ON. When EPIC_ON_FHIR_CA_CERT is set, its
-# PEM contents (e.g. HFH's issuing intermediate CA) are added to a trust store
-# alongside the system roots, so verification still succeeds if the gateway
-# serves an incomplete certificate chain.
+# gateway. TLS verification is always ON.
+#
+# HFH serves an incomplete chain (leaf + Entrust intermediate), so we add the
+# missing trust anchor ourselves. Which anchor is controlled by
+# EPIC_ON_FHIR_CA_PIN_INTERMEDIATE:
+#
+#   * true (default) - pin the Entrust intermediate (EPIC_ON_FHIR_CA_INTERMEDIATE_CERT).
+#     Tighter trust: only certs issued under that one intermediate are accepted.
+#     Requires PARTIAL_CHAIN so a non-self-signed cert can terminate the chain.
+#     Note: the intermediate expires 2027-12-10, so it must be refreshed on HFH's
+#     rotation.
+#   * false - anchor on the long-lived Sectigo root (EPIC_ON_FHIR_CA_ROOT_CERT,
+#     expires 2046). Survives HFH rotating their leaf/intermediate as long as they
+#     stay under that root.
 module Api::EpicOnFhir::SslOptions
   PEM_CERTIFICATE = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
 
   def self.call
     options = { verify: true }
 
-    ca_cert = ENV.fetch('EPIC_ON_FHIR_CA_CERT', nil)
-    options[:cert_store] = build_cert_store(ca_cert) if ca_cert.present?
+    pin_intermediate = ActiveModel::Type::Boolean.new.cast(ENV.fetch('EPIC_ON_FHIR_CA_PIN_INTERMEDIATE', true))
+    ca_cert = pin_intermediate ? ENV.fetch('EPIC_ON_FHIR_CA_INTERMEDIATE_CERT', nil) : ENV.fetch('EPIC_ON_FHIR_CA_ROOT_CERT', nil)
+
+    options[:cert_store] = build_cert_store(ca_cert, pin_intermediate) if ca_cert.present?
 
     options
   end
 
-  def self.build_cert_store(ca_cert)
+  def self.build_cert_store(ca_cert, pin_intermediate)
     store = OpenSSL::X509::Store.new
     store.set_default_paths
+
+    # A pinned intermediate is not a self-signed root, so allow any cert in the
+    # store to terminate the chain.
+    store.flags = OpenSSL::X509::V_FLAG_PARTIAL_CHAIN if pin_intermediate
 
     # Tolerate single-line env values where newlines are escaped as "\n"
     # (e.g. set via `dokku config:set`), as well as real multi-line PEM.

--- a/spec/services/api/epic_on_fhir/ssl_options_spec.rb
+++ b/spec/services/api/epic_on_fhir/ssl_options_spec.rb
@@ -5,53 +5,90 @@ require 'rails_helper'
 describe Api::EpicOnFhir::SslOptions do
   subject { described_class.call }
 
-  # A syntactically valid self-signed cert, standing in for HFH's intermediate.
-  let(:ca_cert) do
+  # Minimal 3-level PKI mirroring HFH's real chain: root -> intermediate -> leaf.
+  # Lets us assert that pinning the intermediate (partial chain) and anchoring on
+  # the root both verify the same leaf, without depending on the system store.
+  def build_cert(common_name, issuer: nil, issuer_key: nil, is_ca: false)
     key = OpenSSL::PKey::RSA.new(2048)
     cert = OpenSSL::X509::Certificate.new
-    cert.subject = cert.issuer = OpenSSL::X509::Name.parse('/CN=Test CA')
+    cert.version = 2
+    cert.serial = rand(1..1_000_000)
+    cert.subject = OpenSSL::X509::Name.parse("/CN=#{common_name}")
+    cert.issuer = issuer ? issuer.subject : cert.subject
+    cert.public_key = key.public_key
     cert.not_before = Time.zone.now - 1
     cert.not_after = Time.zone.now + 3600
-    cert.public_key = key.public_key
-    cert.serial = 1
-    cert.version = 2
-    cert.sign(key, OpenSSL::Digest.new('SHA256'))
-    cert.to_pem
+
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ef.subject_certificate = cert
+    ef.issuer_certificate = issuer || cert
+    cert.add_extension(ef.create_extension('basicConstraints', is_ca ? 'CA:TRUE' : 'CA:FALSE', true))
+
+    cert.sign(issuer_key || key, OpenSSL::Digest.new('SHA256'))
+    [cert, key]
   end
 
-  context 'when EPIC_ON_FHIR_CA_CERT is not set' do
-    before { allow(ENV).to receive(:fetch).and_call_original }
-
-    it 'verifies against the system trust store only' do
-      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_CERT', nil).and_return(nil)
-
-      expect(subject).to eq(verify: true)
-    end
+  let(:pki) do
+    root, root_key = build_cert('Test Root', is_ca: true)
+    intermediate, intermediate_key = build_cert('Test Intermediate', issuer: root, issuer_key: root_key, is_ca: true)
+    leaf, = build_cert('leaf.example.org', issuer: intermediate, issuer_key: intermediate_key)
+    { root: root, intermediate: intermediate, leaf: leaf }
   end
 
-  context 'when EPIC_ON_FHIR_CA_CERT is set' do
-    before do
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_CERT', nil).and_return(ca_cert)
-    end
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_INTERMEDIATE_CERT', nil).and_return(pki[:intermediate].to_pem)
+    allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_ROOT_CERT', nil).and_return(pki[:root].to_pem)
+  end
+
+  context 'by default (EPIC_ON_FHIR_CA_PIN_INTERMEDIATE unset)' do
+    before { allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_PIN_INTERMEDIATE', true).and_return(true) }
 
     it 'keeps verification on' do
       expect(subject[:verify]).to be(true)
     end
 
-    it 'builds a trust store containing the supplied CA' do
-      expect(subject[:cert_store]).to be_a(OpenSSL::X509::Store)
+    it 'pins the intermediate as a trust anchor (partial chain) and verifies the leaf' do
+      store = subject[:cert_store]
+      expect(store.verify(pki[:leaf], [pki[:intermediate]])).to be(true)
     end
   end
 
-  context 'when EPIC_ON_FHIR_CA_CERT is a single line with escaped newlines' do
-    before do
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_CERT', nil).and_return(ca_cert.gsub("\n", '\n'))
+  context 'when EPIC_ON_FHIR_CA_PIN_INTERMEDIATE is false' do
+    before { allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_PIN_INTERMEDIATE', true).and_return('false') }
+
+    it 'anchors on the root and verifies the full chain' do
+      store = subject[:cert_store]
+      expect(store.verify(pki[:leaf], [pki[:intermediate]])).to be(true)
     end
 
-    it 'still builds a trust store' do
-      expect(subject[:cert_store]).to be_a(OpenSSL::X509::Store)
+    it 'rejects a leaf whose chain does not reach the trusted root' do
+      other_root, other_key = build_cert('Rogue Root', is_ca: true)
+      rogue_leaf, = build_cert('rogue.example.org', issuer: other_root, issuer_key: other_key)
+      store = subject[:cert_store]
+      expect(store.verify(rogue_leaf)).to be(false)
+    end
+  end
+
+  context 'when the selected CA cert is a single line with escaped newlines' do
+    before { allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_PIN_INTERMEDIATE', true).and_return(true) }
+
+    it 'still builds a working trust store' do
+      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_INTERMEDIATE_CERT', nil)
+                                   .and_return(pki[:intermediate].to_pem.gsub("\n", '\n'))
+      store = subject[:cert_store]
+      expect(store.verify(pki[:leaf], [pki[:intermediate]])).to be(true)
+    end
+  end
+
+  context 'when the selected CA cert is not set' do
+    before do
+      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_PIN_INTERMEDIATE', true).and_return(true)
+      allow(ENV).to receive(:fetch).with('EPIC_ON_FHIR_CA_INTERMEDIATE_CERT', nil).and_return(nil)
+    end
+
+    it 'verifies against the system trust store only' do
+      expect(subject).to eq(verify: true)
     end
   end
 end


### PR DESCRIPTION
Back-ports 48b93964 (merged to test via PR #593) so dev matches test's HFH Epic-on-FHIR SSL trust logic.