### PR TITLE
chore: bump gems flagged by bundler-audit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     csv (3.3.5)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
@@ -329,7 +329,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.2)
+    json (2.21.1)
     json_schemer (2.4.0)
       bigdecimal
       hana (~> 1.3)
@@ -372,7 +372,7 @@ GEM
     logger (1.7.0)
     logstop (0.4.1)
       logger
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     loofah-activerecord (2.0.0)
@@ -400,7 +400,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_json (1.17.0)
     multipart-post (2.4.1)
     nenv (0.3.0)
@@ -503,8 +503,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
@@ -600,7 +600,8 @@ GEM
       racc (~> 1.5)
       sexp_processor (~> 4.16)
     rubyzip (2.4.1)
-    secure_headers (7.1.0)
+    secure_headers (7.3.0)
+      cgi (>= 0.1)
     securerandom (0.4.1)
     sentry-rails (5.28.1)
       railties (>= 5.0)
@@ -662,7 +663,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
- crass 1.0.6 -> 1.0.7 (GHSA-6jxj-px6v-747w, GHSA-6wmf-3r64-vcwv, GHSA-8vfg-2r28-hvhj, GHSA-wwpr-jff3-395c)
- json 2.19.2 -> 2.21.1 (CVE-2026-54696)
- loofah 2.25.1 -> 2.25.2 (GHSA-5qhf-9phg-95m2, GHSA-8whx-365g-h9vv, GHSA-9wjq-cp2p-hrgf)
- msgpack 1.8.0 -> 1.8.3 (CVE-2026-54522)
- rails-html-sanitizer 1.6.2 -> 1.7.1 (GHSA-cj75-f6xr-r4g7)
- secure_headers 7.1.0 -> 7.3.0 (CVE-2026-54163)
- websocket-driver 0.8.0 -> 0.8.2 (CVE-2026-54463, CVE-2026-54464, CVE-2026-54465, GHSA-2x63-gw47-w4mm)

## Related tasks
- [CIAS-](https://htdevelopers.atlassian.net/browse/CIAS30-)

## What's new?
- 
